### PR TITLE
feat: redesigned landing page (index.html) — 100% match approved design

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,39 +1,906 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-FYT955YV53"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-    
-      gtag('config', 'G-FYT955YV53');
-    </script>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>NhiLe Holding - Kiến Tạo Di Sản, Vững Xây Tương Lai</title>
-    <meta name="description" content="NhiLe Holding đầu tư vào các doanh nghiệp mang giá trị cốt lõi Tâm - Tầm - Đức, dùng lợi nhuận để phục vụ sứ mệnh phát triển con người và cộng đồng." />
-    <meta name="author" content="NhiLe Holding" />
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<!-- Google tag (gtag.js) — preserved from incoming -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-FYT955YV53"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-FYT955YV53');
+</script>
+<meta name="author" content="NhiLe Holding" />
+<link rel="icon" href="/favicon.ico" />
+<meta property="og:title" content="NhiLe Holding — An ecosystem for human growth" />
+<meta property="og:description" content="NhiLe Holding — một hệ sinh thái giúp người Việt hiểu mình, phát triển, kết nối và cho đi." />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="/logo-holding.jpg" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="/logo-holding.jpg" />
+<title>NhiLe Holding — An ecosystem for human growth</title>
+<meta name="description" content="NhiLe Holding — một hệ sinh thái giúp người Việt hiểu mình, phát triển, kết nối và cho đi. Giáo dục · Nội dung · Không gian & cộng đồng · Công nghệ · Vì cộng đồng." />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,500;1,600;1,700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+/* ============ TOKENS (fixed — dark luxury) ============ */
+:root{
+  --bg:#0A0C14;
+  --bg-2:#0F1320;
+  --surface:#161A2B;
+  --surface-2:#1C2236;
+  --text:#F2F3F7;
+  --muted:rgba(242,243,247,.58);
+  --faint:rgba(242,243,247,.34);
+  --hair:rgba(242,243,247,.10);
+  --hair-2:rgba(242,243,247,.16);
 
-    <meta property="og:title" content="NhiLe Holding - Kiến Tạo Di Sản, Vững Xây Tương Lai" />
-    <meta property="og:description" content="NhiLe Holding đầu tư vào các doanh nghiệp mang giá trị cốt lõi Tâm - Tầm - Đức, dùng lợi nhuận để phục vụ sứ mệnh phát triển con người và cộng đồng." />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="/logo-holding.jpg" />
+  /* màu nhóm thương hiệu */
+  --edu:#E5A92B;     /* Giáo dục — gold */
+  --content:#E23744; /* Nội dung & truyền thông — red */
+  --tech:#F2752B;    /* Công nghệ — orange */
+  --space:#46A06B;   /* Không gian & cộng đồng — green */
+  --care:#E8607D;    /* Vì cộng đồng — rose */
 
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="/logo-holding.jpg" />
-    
-    <!-- Preload fonts for better performance -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap&subset=vietnamese,latin" as="style" onload="this.onload=null;this.rel='stylesheet'">
-    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap&subset=vietnamese,latin"></noscript>
-  </head>
+  --font-display:'Playfair Display', Georgia, serif;
+  --font-body:'Inter', system-ui, sans-serif;
+  --font-mono:'Inter', system-ui, sans-serif;
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+  --r-lg:28px;
+  --r-md:18px;
+  --r-sm:12px;
+  --maxw:1180px;
+  --ease:cubic-bezier(.22,.61,.36,1);
+}
+
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family:var(--font-body);
+  font-size:17px;
+  line-height:1.6;
+  -webkit-font-smoothing:antialiased;
+  overflow-x:hidden;
+}
+body::before{
+  /* nền chiều sâu: vầng sáng gold dịu + lưới grain tinh tế */
+  content:"";
+  position:fixed; inset:0; z-index:-2;
+  background:
+    radial-gradient(1100px 700px at 78% -8%, rgba(229,169,43,.14), transparent 60%),
+    radial-gradient(900px 620px at 8% 12%, rgba(70,160,107,.08), transparent 60%),
+    radial-gradient(1000px 800px at 50% 108%, rgba(226,55,68,.07), transparent 60%),
+    linear-gradient(180deg, var(--bg) 0%, var(--bg-2) 55%, var(--bg) 100%);
+}
+body::after{
+  content:""; position:fixed; inset:0; z-index:-1; pointer-events:none; opacity:.5;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.035'/%3E%3C/svg%3E");
+}
+a{color:inherit;text-decoration:none}
+img{max-width:100%}
+.wrap{max-width:var(--maxw);margin:0 auto;padding:0 32px}
+.eyebrow{
+  font-family:var(--font-body);
+  font-size:12.5px; letter-spacing:.26em; text-transform:uppercase;
+  color:var(--faint);
+}
+.serif{font-family:var(--font-display)}
+.ital{font-style:italic;color:var(--edu)}
+
+/* ============ NAV ============ */
+.nav{
+  position:sticky; top:0; z-index:60;
+  background:rgba(10,12,20,.62);
+  backdrop-filter:blur(16px) saturate(140%);
+  -webkit-backdrop-filter:blur(16px) saturate(140%);
+  border-bottom:1px solid var(--hair);
+}
+.nav .wrap{display:flex;align-items:center;justify-content:space-between;height:72px}
+.brand{display:flex;align-items:center;gap:13px;font-weight:600;letter-spacing:.01em}
+.brand .mark{
+  width:38px;height:38px;border-radius:11px;
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAckAAAIACAYAAADpMJeQAABW3UlEQVR42u29eXRc2Xbe933nFggOIAoACYBosgnOY09P/TQ851myJdnWYCuxhnhYsiw5WR6XbCceohU7SqRYnmKvZWtpyU5WIsWDIlmKn2RLlmwpsqUna3hDv36vBzbnmQRBEAALBAcAVefLH/cWUGSTTRAoAPfe+n6r2WQXG0DVOWfvb+9z99kHMMYYY4wxxhhjjDHGGGOMMcYYY4wxxhhjjDHGGGOMMcYYY4wpJvQQGGNMqX36cl97Eq2Rrug5rynvA2qMMSaffvpZf24KSyzB5w1PfC7lZfCNMcYs32eqjd/vyd+1CpHoGhwc7H70qKu7vmmue1O90t2o1LsrjWRTTMKmJDY2N8gtgdgaI7aS3KrIbipuQmCXpE1AqFCqICiRUAGYBCCICo+/R0qAIESAdVJ1RNRF1UEuEJoXwgMJs0HxvoIeMoZHMdGj0KjMNSp62BXxYGEBD2a34wHGxh48Y4y4UYJpkTTGmOVnOPGJ/2513s9z4HyK04/L+rnDw1u2ST3hYexlV9LPhnqRhD4Jg0EYilQ/pF6Q/YB2AOwlsE3SZoJdoLokdgGqkEwAdC29nyUZ4BoogvShmKIOqS5wgdQjAQ8gPCAwI/IGpXMC3qXiqSSJF6ampmaWKZh84u+f/Ds9EXxYJI0xpt2JRbVardZqtdpTHG14hl/9SBGtVqt9jcrWXUGNlxExRGIYwpDAAUD9BHtB7QDYD6hHwjaSmwEkBJ/pxZ8iTk/9357zP60kc+NHZINP/6snPoYkCLhL6DzEz4v6dIX135iamrr+Ed8zvuB71Eo/jDHGmCcyyGp18A0w/G1Be0FcJvhWlN5KMP+lu3fvXn2+0/2ayrahD3ZU5pLdCvEwgRMSXiFxCNBLAAdABn5kRqbliC9fwM+vtwYsp2hnKSMkUzVLP/w5Rf0SgZ+PsfL2vXs3J5/4Pklv7+A+hXCc4F6ysR0I24FYF5LxIJyq13FqdvbWHWeSxhjTZpHs7R/+2SSE/ypKSw/lJAi6QvCLAN4TdF3CLMl6UOxuIFRB7KS0m+BeEPsk7CLRw2xv8wnxe5rwLadwp4y0jgMBkgQk1SWdAfGWwEsBeACoX+AxSB8nuZskhSez0zgH4BLEawR/6O7dW7+OD2+hWySNMeYFIABVq3v7FR59geDezKmGJQHl4rM8Lale9tV8wlEv/V8tv1q3De2Tn01cHPOWcW0VQ0lPE1i0zlUIRD02fuTe9O3vXY5IVjzuxhjz0SIZw8PjAeFlLBXrtPhotfjmJ0Ru6a+EDxfuWBBfPKNPxzId18Ux1YcTv6eNrwDVJYQAzC43KLFIGmPMR4skiOR1EomkBoDkib/P0zO/TpkTrvDrQjp/nHpRZTbGGPMs7yq97lEoT9Aj6IZF0hhjVk8DAEUd91AUHgEIkhYY4wctr1kkjTFmpVlHT8+unRAPZ08X7TOLL5WTCwu4ZZE0xpjVEQCAm3SAxKCHo/jySBIibj14cOfOCy0CY4wxz3CSDRwnWUG29eoRKXAOmXIJwEKmf84kjTFmdSqpIx6E8kDoNxf/6EzSGGNWl3lIOOyhKEm4A0ENvfdCX+RxM8aYpyQcQATe7CK5/0UyD5PbgIeQHnR1Va60BkEWSWOMWSFbBsaHAI1mla0WySKLJAkIlzdtwlWLpDHGrI4AAN2xfhDggIej+CKZtU66OJZe7Lzsq7IsksYY8yzPKh0m2WyC7Uyy+OnkhRfVPoukMcY800PqjUX/asqQTl584SXgYTPGmA8RAVDASQ9FCRLItB1dQ4pfeNGgxyJpjDGPQwDq7+/vBbA/u+vKW63Fn9M76uI5i6QxxqzeoWIhbB6BMJj5U4tkgTNJkhB04/7t25Mv+sUWSWOMeYpIdkUdYAjb8PiFyaaAIplOKt8DUMcy29FZJI0x5iOIsXEyU8bo0SjFjL7fGgRZJI0xZhWZBwJf9VCUZ2egQZxfyRdbJI0x5nGHGgF0tVS2equ12AFPiIrzSaPr4mNBkEXSGGNWlnX097+0i4Db0ZVCJAmClzZtWjhvkTTGmDaI5AI06nZ05RDJtGWrzk5MTMziBdrRWSSNMeYZVFQ/QLK59epMsvixz8WVap5F0hhjniAiNIt23I6uBDsDhE6t9BtYJI0xplUfAZB43UNReJrt6EQlH1gkjTFm9VmHduzYsR3AAbVkIqbISqmaFK+tdGfAImmMMS2CGGNlFNJuuLK1+PpIguLE1q3htkXSGGPaIJKSDjKEzXA7usKLJNN/vfeiFy1bJI0x5hnEpSYCbkdXCqnU26vRO4ukMcZk7hQAAsNhD0V5dgbAxeuxVoRF0hhjltrRBVFHH3OypqgBT5C0gMALFkljjGkDg4ODQ4g44IuWS6KU0nic46XsP1e0fW6RNMaYTBDrdRwEFy9aNgXWR5IgeG12dmzKmaQxxrRBJBvgqyQD3I6u8CKZzerFbC5f6KJli6QxxjzVIfLoY07WFDz00edbgyCLpDHGrIwIAFGLRTum2FlkIkkM8e3VB07GGNPh+QYA7dmzZwuJfW5HVxal1IwWkqur3RmwSBpjLJIAZubmdkt82e3oiq+PTC+RvFardd2ySBpjTBtEEvXkEMkeuB1d8ZNIACDPAtcfYoXt6CySxhjT6lljPMZUGt2OrhxSeakdOmeRNMbYnQIg+IaHojwE4Eqbvo8xxnQszXZ0CYOOt7xmCqyPkqKkUxZJY4xpA1t2vDwMYL9ctFOGXQFCulPvxnutOwUWSWOMWVkmia6Fhd0ABzwcxRdJpg+Wr9y/fftO9tqqnjFbJI0xHS+SSRIPk0zgdnRlyCSb12M12qFxFkljTMcTgVcec7Km6HyxNQiySBpjzIr1ERB40kNRCoIEROlM276hx9QY06EQgHbs2LGdwDHfIVl4mkU7Cwl0pV07AxZJY0wniyTm1LUH0MuLxyVNgUWSEHUjxu5r7RLJisd17Y3wGRGPMSYH9smoQ2DYgrRpq0WywCLJtAHde7WZ61NYZTs6i+T6GKCe8/etv1rF81m/G2PaTKAOk4SUNhXwiBTd8fJcc2qRVrhaJPMa1QwPD297+LCru6vr4cLk5OR9PH5eRy8ofqFFUPWU72EhNeYFbRQAJJyk88fS7AxE6Gw7v6lFcg0CUwCxr2/w9Udz+CmEhZ56rMz19g/XCEWIC6DqEhYAXCZ5Q9I8hYckzpOabITkEULjbnxYubt9Ox6MjY09wPMPxBIffsasFYixMZ1CBFAheMJDUQ7fK0lB8VQ7v6lFcq2iGfITgeFYdjcdArO/yn5vjVzZ8h9RAqOkRrgXKvHeg4ea7e0fuknhjogxgjWJtwLw/gJ1p5sL16amph4AqH/E1kIzC7V4GrNkp9o2NLQD89jfNFMPS6F3BSigBoXrrTsFFsn8WuAJQBFQA0AifWhCH5vcJ7JBkugF2AsSATi6qK8ASEASEmiurspYb/9wDdBVijdAnQN1mTGZlHSlVhu/AWBhGdmnhdN0VNYBoBEWdBDkTle2lkEkSUITta3JLdQsknkmAggCXmFqiFpBhJpNrgQh++fDRk6wG+C+NBHl680sFQBEAcR0b9/QDRCnQV6FdJaR5wBdDmFhcnp6uvaM7DOxcJrOsNZwhAkTSdGZZMETEwIx4irSx1NtqWy1SK5JAgn17tnTz/sLx7IbBcIKv89yIlsByn7MYwuiWeDTH0LoR7PlFgkFQeJMA113q33Dp0C9LeBdNHghRl6anb018RThdMZpSupYdTIzM6/nwmeSAInfbt0psEjmVCTD7PwecV1uFOBzhFSZhLY6gCTdyg29DNgL8BsIQIliCBrr7R+6gIhLCPgdkF9Avev8THrm6MkFF1qiNYumKVwOmTnVox6K0vheCIvXY7UNi+RaTFTQYSJ052AL51ki2sxA1ZopktxNcjcSfDWAPykpKszf7O0fPgPxCwGN9+sh+ezs1K1zSAuFLJqmsMHsnj17ttybnT8kLtmuKWwWmV60TFy2SBZhxhQOZwWryrGT4HOEM8s6wx4Se0B8HZAgxPiwt3/4NKAvAfiMyLdZ7zqXZZsWTVMYkaw9ii8TfJm+aLkUUyrpVpzHpdadAotkflXyCIp3OnlZwklyC8mPAfwYgO+WBCXzV6t9Q79F8Ddjws90h8YHExMTs098r6Rl8VowzUavdST1+jGF0AO5HV3BiSQSCZfu3x+/40wy34YXkW5bHm41xoJ/pg8J5xPPORMi7E2fb+KPMqo+H8OVat/QWxB/KcbGb927d6d5AerTsszopWM2xLMCr2Xl525HVwoPrAtNH+xMMsc5ZE/PyA4oHixxqvSkcD6ZbVYAHmTgQQD/NRnuV/uG31G6NfvLIW76nVrt6vQT3695VMbbsmZd7DTbFXHRTrlm9fxaJCcWyfYRADQqlYXjYjKc3SjQCeeuPko0SXIbyU8Q+ISEv6zw6Gq1b+gzIv5jZPj12albHzyRZSYWTLPG6zXNHKXDcNPWUvje1NvqM2vxzS2SbaYB7k/IIKWddjrUCT0mmi3bs6G5NUvgOxjjg96+od8h9R8Qu36lVrv5Lh6vmrVgmjWhZ2SkHw/jXrejK8WuAAXV2AjnWncK2pn9mHYOKHnMo/Ah0QyZ4BFQlNSQ1AC5NYTwtWTy9xAan6v2D/1Ob9/Q3+jdsevjWQDXwFKhT+L1atrl85IHGAUx6NirBCJJgtKtrVvD+FqIpDPJ9hGzGTvqDZxlB2bKzpIC6XGTN0m8qaj/pbd/+F0C/w6x8ala7c4XsbQl2xRdV8malRsr9UogK3A7usKLJAFE4txYm9vRWSTbny0JOLGJutM8/mGtXN64JS2C2dxWrQTyYwA+phD+erV/+LMAfiHWG596olLWx0rMChdePEGEZ/VFNsWTyrMtQXijnd/aItlGkaxWJ18S+TJ8OHmlY8gPCyY3kfwkgE8ySf5GtX/o10D+m3nWf+nh5OTNlq9vPr/0kRLzkUlktthe8VCUyn1cWKvvbJFsn4MHoIMEq3j8+ivTJsEksZ0MfwjAH9oUk9ub+oZ/FtLP1Go7fwM4Nd8SSdLZpXlWMDs4ONgzX+cRPWa7pqAECRAXO+20/wd4jNuY8Qd+eXaBsrOZ9jq2ZuGPFot+wCEG/hkE/n+9/ZOfrfYP/ZVqdXh/NvYNLBX72Amax4LZRiPZK+kl7/gU3+UCIBTvdDF5t+U1i2ROJwuAjngo1tzJJa2CCQCBfJ0M/wBBn6/2Df1UdWDo67H0bMKVseYxkayrsZcMW+Edn8L73SwpuTA1deOmRTLfhhez3w94ONZdMCGlx0oADjCEPwLxV3r7hv9zb9/w927bNjSMpaMkwWveBPJo1kPAOz5lSE7I1nZ0Fsm8Uq2OVgGMZoeTHZ2us9/7UHYZ+IkQ+MNJFz5X7R/6O319Q69lhhRbBNbz1IFONQqveShKNKnS+607BRbJfGY0qIdHeyiONNtCeljykV2S4WUyfJ+Iz/T2D/2znv6RT2bO0s8tO48IgBSPr6VTNesaHIPCqTX/IWb1IlkJOoTA7pZMxeQiu1zcit0cGL4rQfz1at/wL2/vG/6DWOrqY7HsEIe6defOXQD2y0U7ZdgVoKQFQJdbdwoskjkVSTVwkms4UWa1Yrm4FRsY+PsC8fPVvuHf6Ovb9V3AiU0Wy86w06QR9oEYciZZGq28293NMYtkvomZuX2ZhyL3TrJVLMXAr0LAP6v23/nN6sDw94yOjm62WJY8Yoo6SrKt9w2ajVFHkhBw6vbt2xNYg3Z0Fsn2Od4IoAvgIUenhRJLZs8tIxk+TvDHpmce/VZ1YPi7gZGtT4ilKY1KhsNrmXWY9RPJzJjfw1Jl69osGY/1qh0u+vtHRgjt9nOO4rlMAKEploH8GMEf7+2Pv9XbP/THsPTMkhbLwpNdQADf0lMmpRQ/WA8nYVYpkgvAXoADziRLI5avk+H/qfYN/8b2vqFvwVI1rM9ZFtdOBRzqphYbfthOC26zkoAQz1kkC0AS4yGmrR/8nKMkYgkpMvCrAsO/qfYN/7u+vp1fg6Vzln5eWcBgtlqd2S1w1Ds+xU8gAVBAjQ2eb3nNIpnbGaNOrPVEmQ0SS0gM/CYx+dXe/qEf6+8ffgV+XllIkVQIR0huh9vRFV8k04uWx7ZuTW5ZJPNN89qdVz0UpRVLZtWwSWD4nobw29X+4R/Yvv2lHVh6Xmk7KoRSxhNuR1eSvCT919haXbRskWxfdKpqtdon4mi2hePxLCeLR0dI9JD8/lBpfKavb+g7W4Ilb8HmOfMAIPkOyXJ5YL69Hjpmp746kUQ9bN5DYI+HoyPme+mcJXkQDP+i2j/8H7YPDH8lvAWb53nLdnzoW3pK5HshfX49fphFcpUTVYk6BIQu+DlHZ4mlFAVFkr8vCP+pd2D4H7RswboKNmds3/7SDkGj3vEpxa5AkNRAI5xr3SmwSOaVIF+706Ezv2iswJaA8FdCpfGfqwO7vgOPV8GajZ8noKt+mOSIh6M0+cntRiNecyaZ/4gGAk96KDqabAs2NkgeI/DT1b6hn6pWh/fDhT35UcoGT5BMWubEFJNIApAu3r9/e6L5mkUyp5MFIFCL7ehMZ4e2yWKbuxD+CAJ+s1od/u4smHJWudETFFyBXqr5JM5hjdvRWSTbkO9v2zY0COqgn3OYFnvKtmA5woQ/Xh3Y9dMtWWVwFrMhwSwkt6MrEwKvrpeG2bGvYty6upIjAHfATQTM4yRpEawige8Q8Rt9fYPflTlsV8CubzCr4eHhbYD2qyXANcVOUAS8v6iXFskch6hsnMyec/iiZfM0Yw7p2UruRkj+WW//rh/bNjQ0nGWVPle5Tg710SMNC9wNt6MrfgIJBCk+6grhHYtkIabMzyPNsrLKrHE6vqeywE9XB4a+PhNK2+A6iCQq2E9iG3xMq/giSQLgtUplsbLVIpnXJBIASB31UJhl2lkzqzwC8Rer/cM/mL3uop619qxpZasvIChDWgJAwtXx8fH7WON2dBbJ1UWn2rNnzxYJBx6LWI15TlaZNk1HF8n/qdo3/PPV6vA+LG2/mrXxra97DErkgKkP1lO/LJIrE0nMztaHQPqiZbMSm0v7wAZ+owJ+rbd/8BuwdH7Pa6l9dpoFHzzuYLZEIQ90ar0N1qxAJJXEQyR64eccZmVrKMm2X0eJ8PPV/uG/nq0l2S7bx+Dg4CChQw5myxFgprO4eIekRTLn4cxrhJ9zmFWRIN1+TUj+vWr/8L+oVqt98HPKtgWzj+rcD3KHh6MEHhegou5pIV5uec0imdPJAsQv81CYdtlgllV+J8LmX+4Z2HUcfk7ZFpGkcMDHtMrhd0mC0Ol79+5csEjm2/CaxrbPw2HauK6a269fnkT9am//rm+Az1OufmDJY+vpUM0aJyfkGSy1o7NI5pXe3j39gvZKSxGrMW0gye6qHCH0c739g38OS+cpvc5W4FQF+AKCUqWTOrfe9mCRfPGIH+TcXgK7Mju08zJtFUpAEUB3YPKj1f6hv4Ol82C21+XbaRwdHd1M6bjb0ZVjTtMKyXBqvX+wjW4FIokEh8iwCX7OYdbOLtPerwzfV+0f/hdp/9H1ufWgLHY6NXV/r9vRlWZXIEBaQIMXW3cKLJL5nbJX13uiTEc6embPKf/4o3n87LZtw0Nw5evyg9kKDgZyO3xMqzRxT6OhdWtHZ5FceUQDyRctm3XzDImkOsnfV9mEX+zr2zUKV74ujxiOZdLoY1pF97sEBNycnb11d71/uEXyxRxW3LNnzxaCr/o5h1lHKplQvino3/cMDJywUC7DYMkTHoVyiGS6rYLPAljI1r0zybzm+/fuzY8I2OXnHGYDhLLBwGMhdv37anXkTQvls4NZAAR1wMNRJqWMX9qIn2uRfEGRBLg3a0dnkTTrTfMs5csI8d/19O366kwoKx6ax/1ptVqtAjjkY1qlICh9qnzBIlmM6Tqc3rqzeH7NmHUVSkANksMJ9a97+nZ+DYC6M8ong9mu/QRf8jGt4gc8SAvYZlDHunbasUiu1ALlOyRNPjJKkDsTJp/q6xv53c4oHxdJheQoyQp8TKvwIpm1o7u+bVtlzCKZb2I6O4vX7hizsRmlFEEOiPHf9PcPfjLLKC2UqSr6mFZ5MkkAvD42NvYA63TRskVyZdGpBgcHe0AeaY1YjdlAQiaU/RHh53p7h78C3npNg1nBwWy5uLhRmmWRXL5IYn4ehwCM+m46kzehJLkDAf9vf//Qq+jcqtdmlrEJ0GEHs+XxvRHxtzbOwMyyJwrAAZJd8HMOkzOhlNQIgS9H8Weq1eF9mVCGTrTTvr5dIyR3O5gtPMrW9kJQ5VTLaxbJ3M4YF59H+jmHyRtJdo7yqAI+NTQ0NIzO6/WaFu1IBwH0w+3oyiKVk/XNcd3b0VkkXzyiab2bzpjcCmUgP/ZoAT85ODjY02FCwSyvfiM7puV2dIXPSwgAl+6Pj09u1JuwSC7P8NKIXHLRjimIUIbfO18P/3u2Vtkha7ZZtOPeyiVKTgSdwdLjA2eSeWXr4OAQiH1+zmEKIpR1kn+82j/0Q1jadi3zul1sR8elY1q203JwbiPn0yK5PONDUscBgEMeDlOkjJIM39fbP/Rn0CGFPD09u3YK2Ot2dOXxveDiHZIbgkVymWNEhY+1tKOz8ZkiOJggSQT/UbU69HUo99GQNJhNGrtJDLu2rvAIQIjSwwr5pZbXLJI5nSyAOOShMAUUDoHcDPKfV6vD+0ucUaaBa8L9bkdXDr9LEhSuJUljwypbLZLLI6aZ5GLRjjFFIiA9GvISiJ/YsWPHdpS44lVxsWjHqWQZkhPo4sTExCw2oB2dRfIFIvERjGwFsO+xiNWY4tA8Q/mJhUbyjzNnUzbbbzrQ1z3dpUonT2+0Vlkkny+SeFBt7BL4sitbTcGFsh5C+J7evuG/gHI9n8wqW0c3AzjmYLY8vpfQ+xv9RiySy5gogPtIbIe3cEzxhTIS/Lvb+wd/F8rzfJIA0Nv7YDdA91Yuie+VJCqcs0gWYbYSvNLSwcPGZ4od9AX0BIUf6+3dM4BybL2mn6vCAyRL/cy1Q8jmTw9jV+NGy2sWyZxOFiR8uYfClIRmIc9RJgv/uEVQii8qkcfSWNbt6Irud0lC4NmZiYkNrWy1SD4/Os3a0fn4hykVWaMBfmdv/9CfRUm2XcXF67FMCZITAqcAzGGD2tFZJJdJz8jIAIA97uBhypZRSooQ/15///DJggtlekwLPOFpLZFSCu+1JCwbZyieio/MJJE8WHgZSx08LJKmVOs7BPZG4Edx6FB3HhzSCj+HqtW9/ZCOZEU79muFD+AAhng2F2/G8/HRTkQhOeqLlk2Js8kGya/uvTPz11DM+yczsX+0h4R7K5cggQRAKT4K4tmW1yySObbAY3mYKGPWUCgjie/r3bHr4yjetmtads5wlAzdDmbLIJIEiFsxbr5ukcx/RAMBr3ooTLnjQIgM29iIP3IIxdx2VXQwW5oFSYDAeK12ddoimW/HEYeHh7dROqkCOg1jXoCsbV34yon+e38Zxdp2zYoFoi9aLlFyAuCt5trc6DdkkXy2SOLhw7hLwB64g4cpP2m1K/A3BgZ2nUAxtl2bx7QSEAc8heXxvYj8Qm4Mw3Py7IlihftJboM7eJhOWfPk9kaM/xAF6uu6devgIID9rmwtTbCmRohnLJJFyPuFQy3t6IzpBAfVYAjfsL1v6I8h/9uuAQA2bdJhgDvg55GFd7nZ79MVJRveacciubzQ2oeTTcctewkK5A/09IzsRAF6u4rhOMkAV7YWXiTTdnS4dvfuwJhFMt/EbMp80bLpuGwSUCR5IFTi9xUkO3vD01aiTFK4CJyaxwZetGyRfG4CCQ0ODvaIOuJ2dKYThTK9Ukt/tq9v8HXkc9u1WbQDLZ1lNiUQyQBcyZM+WSSfbnyYn9dRgrvdjs50aqDIELaJ/Fs5Xv/q7++vAtjvYLYcwVm2/L6YwzdlnhRJheQwyU3wcw7TmSTpkZDwzf39O78RzaMWObPTBXbvptxbuSRZZJC0INXfac0sLZJ5DWmkI3maKGM2RIkIRoXvzxqg5+koFAGgEuNhhrDFwWwZRJIQNAZsu2SRzH9EA5G+m844VpQiQ/jK3smZb0MOn03GgNcczJbD72bt6C7XaldmLJI5DpzR3FaSL3A1ZtEwhL+5Y8eO7TnK2NL91Qi3oyuVVOoUcra1b5F8CtuGh3cAHHUxgDGL2eTxhUblu5CPc5PNYLZL5NGW10zRg7EQPsidAXhaPmR8SBawD8TgUkWyMQ7xCXzvwMBAb16yyYGBgWFCL8u9lUvjexF12SJZgImi9BrJBG5HZ0yWTUIMPFqPXX8yB9lkAIAYw36AA/DzyMJHYABCjHpA8kLLaxbJHPuEN/I2UcbkwZkR+vODg4M9ucgmA/czba7sytbCiyQB6OL09Pg5i2S+ydrRydfuGPOhbFJiCMfm6vgTOcgmESNdtFOW4IsAiLMA5rN1ZZHMIQSgkZGRraAO+KJlY54a8gPi925wNhlT4+RrnpFSOeCzyKHftUg+LpK4X6+/JPElX7RszFP8RVbpOlcP37RB2WTaWxmDPSCOOJgtj+8V8G4+F715bKI4H/aS2A5ftGzMU5NJAqDwFwF0bUA2mbaj6+MBQLsdzJZicyJIagjIVacdi+SzPcAJX7RszDNJJAnE7+rtH/zaDcgm06xDOECGvLXKMytXynt1brpqkcx/RANAb3gojPlIIklS/O6Ncmri4oXoDmaLnpekScmVh1Ob7+TxDVokl6LTCIDEYi9IR6fGPMNvKD3B/19u6x8+ifXt6drsg+W2keVKTt4Czs8hbUfnTDKv9PSM7AAw4g4exjw/qGQIWxLpu9YxqFwKZuV2dOWKuvBObt+bp2fJ0JKEL4Mc9nAYsxybEQh+W3bxcWO9BGvHjh0jgA7JrT5KoY/ZcrpokSyASCo0jpDciIo9Y4oX/AuRgQel7m9ZJ39CAJhXshfkoC9aLjwCwBg120iSsy2vWSTzq5TxRF4nypicOjmI+k4sbYWuuUgGsLUC3SJZ5PVDgsD1zWHhhkWyCMaucMJDYcyLZJOCpE/2DAwcxzodB1GEg9mS+F2m/7oxMTExmwU8FslcJpBAxKFD3SBcDGDMi9lOI4SwNVHXH18H20nb0VHHPPRlWkQ6nWc9skhmRr397t1RSAdd2WrMi9lPtg3z7Vk/17Uq4MmyjEPdEvY5mC2P76X0mTy/SYtk8zmHkj0kt8IdPIx5MR8iCeSRuQY/sYZ+hQBQrd57CaAvWi4+i+3oYgxnWl6zSOZ2xho85nZ0xqyItANP5LevobPLKtB5lGSvg9myOF5NdXXVr1skCzFZ8agHwZiV+ZEss/vm3t49A1ibqtN0aw7xRBrLOpgtusfNkpLLk5OTt3O9uD1XzWIAuhjAmJULWGTgblbmfu8a+ZaYxrLwHZIlEcls6ZwHUEfOLlq2SD5u3NqxY8d2EM0OHt7CMWaFTo/iNz3uBNsqkgkJB7Pl8sDnW3cKLJL5FEnMqetlQLvdwcOYlduSJETg66vVaj/au+VKANg2NLQT5GgWzHoXrAS+N0pn8/5GLZIAgvRadjedO3gYs3JfIiLsBbq/ps3+hQBQmUv2ABh0D4FS7DqEGOMjhfCFNdp5sEi2dRCkQ3mfKGMKQCQBse1brq29lRMHs2UQSYLktS1JI5cXLVskH49oIBftGNMWMUvPZeirMTKyte1ipvCGg9ly+F2mrSEu5bkdnUVyqSFzAulwa8RqjFmhTaWNBQ71PVx4s40+Jj3uwXjSQ1yq1fJBEXSo47dbtw4ODgLY5w4exrQn8CSZiOEb2/g9NTg42EPhoCvQS5ROQh8U4X12eiaJpMF9IHd4yRrTPruC+HsAVLD6Xq4EgEfSSwJedgV6KQjphgMuWCQLYMyhweNZMUDDxmfM6u1KEgScrFaH9j4mnKsR3UZymOQ2uB1d8RNIgIAeNpjkuh2dRXIppvm4160xbQ0+YwjsVeDH2yCSAIBEOuTeyuUQSZIQeG52sv+iRTLfxGzKDnndGtP2bAGAfn+7nKDA4x7W8qwNSh8Ap+aR43Z0nS6Si8UAIPa7GMCYttsXKHwVRkc3Y3VHQdIKdODVdmWlJg9SuXjRcu7ns5NFEnNz2CVhxMUAxrTXvrLnkgf7ag+OrsIZEoB6enYNADrsCvTy+F6F8EFR3nBHiyTJUZI98OFkY9ptXzGEsBlI3liFSAYAYFc8BHLAw1r8/BFpZes8YzjX8ppFMrczFnSk5W46R6jGtNchQtRXrNYZhshjbkdXqpVxp9HQNYtkIcLd8IpXrDFrlk1C0FchPS+5coELOlIUh2o+Wh5JQtT47OytqaK86dChxtvIPvtrrQZtjGmfnUkCgaO9g4P7VmhnaTYKHvFwlmd3geLnWnywM8m80tOzawfki5aNWcNgNJJhGxsrei6Z9VY+sQnAQQezZVLK+KUizWenZpIIYWEUxE7v4BiztpkDpNdWaqd9fVMjgEZd2VoKggQw8Gyh3nSniiSS5DDJ1T0rMcYsRymbt3fEF7XTGOMRIvTB7ejKEDBRUE11XX4siLJI5lUpeaJIE2VMYQNS4DAwunklQhcCj7dUoJsCiyRJQLo+07+1ED1bO1kks2IAuM2VMWsskpJA6cD2nfdX1Ow8Aq5AL5HfJXEJV648Qs4vWu5kkVwqBpCOaQVGa4x5MXtjCNtC5Iu0lWtWoBOUeyuXa0lcK5r2dKJIondwYi/Al+FiAGPWJ4NYQYPyHTt29BAcdQV6eXwviM8V7Y13pEiigQMM6IWLAYxZF6J4tFU0l2Onj2JlryT3Vi5HoBQk1VXnexbJYkzZQcJ30xmzbtGpsD/zN8upJicAVKgjIYQtDmZLw51GQ1eacZNFMtfppO+mM2a9fIwEiNpTrVaryzZRAIzhtaI5VPP0tCSrbL1y//74VOEWcIdNVmZsi1s/xpi195GAsDPGbYOtIvg8O42IrmwtzQIARJ4BUEdB2tF1okgSgPbs2bMFwqgrW41ZP7sjwzZW4oFliGRWgY4ucrFnq+20HHxQxPnsNJFE7VF8GZArW41ZPyIJKMbjy7XT/v6XdgHa7XZ05fG9JC8U8c13nEgm9cZRBG6FiwGMWV8D5GKXq+faKaC9wOJFy7bT4iIAIcZ4vwG81/KaRTK3IS34hitbjdkIldTwohk+N/WMR0jSdloCkSRB4Mrs9u5LFsn8RzQg5bvpjFlnecx+2wtgE5axi6Mo91Yuid9NH0rjQtHa0XWaSDYj0gqko48brjFmzXNICRR29vTset4xkJga57K2Zk1xpPJsUTWnk0QSO3bsGALhu+mM2RhP2U+G/o8IUglAw8PD20BfiF4m30vF94v6ATpKJDWf7AW405mkMRthhdyiJO56jkhiYYGjkPa6HV3xoyKk7ehE6kJRP0RHiWSjgldIBqQ3DBhj1s/+IkgmigPPs9OFGA+BYUX3T5ocKqVwX0qutQinRTKnEQ0InvSSNWZjbJCpx9n5XKdEHvNFyyXxuyRAXKz1bR6zSOabrM2V3vC6NWZDk8r9zwtmJVeglyowgr6UVbYWqh1dJ4kkAWjHjh3bCe5xMYAxG5pbDHyEnUYAgYB7tpbKAfP9ljkuHJ0ikphn94jvpjNmw2n2b41Ps9MtAwMjIA5nFejBw1VoQupt47lCf4hOEUk2FvaTYRtcDGDMhtmhoN0AKs+yw0TJPoD9Hq4S7BkAhOKjoHC25TWLZH6nLBxxMYAxG2iCAkh2Yc+ermeJaAKezNrRNRzMFl0kCQG3Yuy+YZEsxid91evWmA13nT09dxvbnv3XPOZBKsdMkwDFsVrt6l2LZH5ZKgaIcJsrYzbUFgUBveTC0273SNvRCRbJcqWT72XiWFit6QSR1JYdO3aBOupiAGM22CCJTSFs2vY0Ox0ZGdkKYL8vRC/TfOuzKPh8doJIohKTUd9NZ0wuqMSk3v00O703j72C9vlC9FKQSEKATi8llRbJHOf84VDWjs5FO8ZsXMAqAIFS3xMBa3Yhuk6GEDZndmqRLLDHzX6bAipXi/5hOkIkAxevx/LddMZsoPNMC1fDU6/LUhKP2U5LIpIkBFybnh675UyyABGNsCiSxpiNdjqK3U+zU0ZXoJcmGEp/PwdgHgW8aLlTRDKrbD3UDdAXLRuTl6CV3PRhO0UFwCHbaalm+2IZdKbsIom+vtldAPb6omVjcuI7xSczSWwbGtoBco/ttDy+V9B7ZfgwpRfJBnGCZBVuR2dMTkRSXU/aaWUu2Q1gh0enFLsFQYrzFfKLrTsIFsmckjAeyZTRla3G5MEmk9D7oawjNI6SrMCVrSUQSULAWIxbCnvRckeJpAQX7RiT30yyqZSvlcGhmrQdHYCrtdqVWhk+UJlFMqYWR1/gakyuMw9XoJdQKk9nc5s4k8wnLRctY78vWjYmVx40abHTCLzZBYQDLa+Zojtg6VRZPkuZRRJz6trji5aNyV3uGFrttL//5gghV6CXyPfGwHNl+UClFslKjIcZwha4GMCYPGlk5ndOpA41xoNA6Icr0Is/tUBQjI8q0NWW1yySeSUCb7AkE2VMiXzp434n6KAvRC+JSKYTeXF6uvesRTL/EQ0YcNLr1pjc8WS2+IaHpBx+l+m/TgPn5zJ9sUjm1AAjgATC/mcYpTFmw0XyVCP1QXzdQ1KmyQ1ny+R3S7vdunXnziEAoy4GMCa3NPr7+7cL2usK9PIEP1J8r0wfqowiGQAgaYR9AHd63RqTX6SuUQLDrkAv/lQCCJLqWKpsLUUtSHkLdyKPtly0bOMzJo+eNYSjZOi2nZYm6pmqP4qlqWwttUiSeKVME2VMiWgs/UlNO3Vla8HlkSRE3njwYGKqTB+sjCKZRqR0xZwxeU03WjyQ75AsyaQCAIXPIr1oufDt6Moqks12dD2ADrgYwJhcMgsAJ3Bik6BjskiWSCnju2X7TGUUScyj+yUKQy4GMCaHRsrwAABuVO/sAXgArkAvjZaIyUWLZAFEkjHuB8M2uM2VMfnLNqS5zFxHCfTBmWTxE0iAMWoW9XCh5TWLZH4j1XjMba6Myat96mH2x1Gmhmo7LbpIkiBwc/PmhZsWySIQedzr1pj86SMAUHgIAKKOl82hdqpIZu3ork1MTMxm82yRzCnN0vJXWo3SlCBSNeWZTCUPMuN8xaNRKiu9VEZdKdOHIQBs3bpzBMBBt6MrXwZiij+PksAuTWaRzz7Pb4kml/pcGT9X6UQy6Q77QAx5yZYl69AjCTMeiVLsBhBAfaGhyd7ePQMkRhzMlmJeE0mNCL1Xxg9YOpEksJ9pNYDbXBWbSBIEvwDiiy7wKI1PbXSJszHUXwHoi5bLM6/Tm0K83CKcFsn8hjU8WsaJ6tAIFQJ+m8J9D0dZdgZQr9d5PzCecOBTjinN5vHy5OTkhEWyAE6V8kXLZdoZAHVexC4PRxnskyA4s2N20ywUDnhIyuN3AZ4GsICSXLRcRpFsbq92kTj8mJM1RTW8EGOcDwqnIG32kJTASAkIuHsFVx5BOuIRKdMOgc6U1e+WSSRRrQ7vlrDPxQAlEEkSIG5Iukayy3vnZRFK3R8eHt6GgAMOZsvje0FcKOsHLJVIKsRjJHvhYoDCiyQBUDizdWsYF1TxE+ZS7A4A4p35+fkdEEYdzJZiTkOM8UGF4UuPzbNFMq9KGV51O7oyWaDeHxsbewQx8WiUw0IlnGmEMEyi15lkCUyUBIkbU126YpEswowJfs5Rpp0BJO/AR3nKNbEB9xCTN8kAtF6+bArpclND5SWMj99HydrRlU0kIwCSOux1W451KSki6AyArscu6TWFTjwATUP4uE9olSny0ekyJl1lEkkCULU6WhUw6gtcS+FJAWhS87wIDG/yfJbH10ThNslR2E5LZLDhVOkXbglEEo1kboTCLl/gWnybSw8n8+rs7K071ermLk9nSfINCYF8CcABB7Pl0A8JYIwXSv0hyyKSlRiPMITN8DOsUmSSAq4AUIwLSfPRhyn4xEqPBLwEaZd30EthpwTio1hpXGu1XYtkTolL1+7Y+koR+ehs5ljpOS1H4ANwnsJRkFvhTLLwc0oSEi7cm+wpbWVrWUSyaYAf87otiT6mXATSaiyLZDnmlMRWEV/l4ShP4EPgPeDKI5SwHV1ZRDJrR3diE+gOHiUxvCBJAToFACFUIuhzryWhQqDPw1Aqgz1Vdr9bBpFEf//dYcIdPEpkepNk9+VUJO9Fgj5PV7IMxJRjdwDk2bJ/0FKIpBT3A+j3ui2+AyUJgVenpq7fSkUyRDvWEjpXU/RAJ0hxnjGeLnvwU4rCHQUdyi5abtgIi59lEPggm0tMVioRbjNoTM7slBBwK8auUle2lkYkGRcrW00ZLFBaes4x3hUhRYc+xuTI5xIgcOvevZtTZf+sRRfJCICiRbIstgcAXLqbDsDmCPf4NCZnmSQA8K3sz6WtbC26SGbt6KpVQUezs8nB67fQhhckLQCtd9Odb4hccCJpTN4MVl9qDW4tkjnNOpJky0sEBl3bUQaRJARdD6F+qXW3gNAjD48x+dENSWDkmY74sEUXyQXVR8GwBb5oufAiSQIQL05PT9eyuSSAKHC8Jds0xmxoMAsKqEnxWifYZeG3J0MMxzJldAVkCSD1/pNrk8J9j4wxORFJEpSu9/dvvWGRLEb6cdzrtlS89+Rugag5D4sxOXG5qWVevHLlyiOU9KLlsohkeiaSOuJ1WwoSSaKS0x/KLkWLpDH54kpZEq2yiiQBoFrd2wfhYFbZ6ueRBY5Os3899TmHgFkPkTH58b0g3+6UDxyK/L5jfHSU5MhSoxZTVJFk+pxjrFbbfOtDIind8BAZk4tgNkiqo5G8/aSdWiTzSIJDJBP4ouWSZJI8/dRrd4iJx6JYY8wG2SkB6ZYUSn2HZGlEMpBHO2WiOgES7z9tXSbAjEfHmI0XSaZVO1dmZq7f7ZQPXVSRjJkynvS6LYc+ZvP57hNBT7qPTk0qvQet1O2vjCmGUupM5oMTZ5L5dagC0A0tVrZ6G67ANof0OcdcUDzztJ0BMpkGfAzEmHw4YH3QSZ+3qCKJanX4JZB7fNFyScxOmohx7qkdPCTOAnzgcTJm430vIi9YJAswUUriYQJVuB1d0YlMG9BdnpmZufuULBMxbpoRVFvalTXGrDMCEGKMD0LA+acFsxbJ3LnW8GZ6z7Lb0ZWE89lcfui5Y6227QHAGh0KGbNxIkmCwKXp6dtnLZL5j2gQoENet+WB4KnWnYLHObUA4F4nGaYxefO7aWErzwOYQwcV0RVNJJllG4zEQa/b8qxBCqefERA1C7WmPFTGbLBSanGrtWP2dQq53VqtVqsARt2Orvg2B4Axxof1wGc958jWqCySxmxsgoIAvtuRUXzhJips3k1gl9vRlUEkCZI3u7lw/Rki2Xx1wsNlzIYFs0FSJBsXOu3DF1IkJR0Ew2a4srXwxpdetIxzk5OT9/AR1+6Qi9s8xpiNUcp7QFezHV3HFEwWUiQj8IovWi4R1Pnnrkcubrc6KDJm3YNZAsCV6emujtvRKZpINgAgkB/3ui2RBYqnPzqABcTkqqQG3JrOmA1IIgECX8wuIEg6yQaLJJLNrbhNkg47qyjH+pMkhHjuuZNf14SE+x4yYzaM9zrSSRVMJLN2dNjtdnSliE4pYCZR5XRrxPq0KLZSqU+SuO2uO8ZsjO8F44VO/PCFE0mSowD7nEmWQCTTDh5Xpqf7b32ESAIAJicn7wm6kXXdsUgas37BbIgxPgwKZ55npxbJPMwY42GmT5FdtFNw48tKlc8Ap+bx7GeNalmnlzxsxqy3SKbHtIBt1y2SRZgx8UQnTlSJLfDdZewKpOdjFS56xIxZ52CWgKDr09MXZ/ARx7QskhtPBAASr3jdloLsOcfyzz8q6LqHzZiNsFaew+O7OhbJHDpU9fbuGRB0NGtHF7xyi5xAIkiqMybLvlGg3sAlpRVbPgZizHo6YOmznfrZiySSCGF+D4GX7B9Lo5VTC10LN5cpqtgUkgsCanDBljHrFcwmktRQPL3cYNYiuYEiCWA/ESpwO7qiE5k+6Lj04M6d283XnieS09M3xwFcy7p/OFIyZn2428XFdnTOJHMd1pDHMml0ZWsZSJ9zNJaxDptB0TyAC50a0Rqz/i6XEHBlenrbuDPJ/Kf9IHjM67ZULKey9bG1yqWvMcasg9+FcB4431EXLRdRJCMACjrkdVuOdZe12zn1wlYrnXkBYTXGrBJS5zrZ5oogkgSA7dtfGoBw0JWtpYhOqfSi5YuPRazLiWqTcFZShCtcjVkX30vpdEdH9EWZKKBxCMSg/WIZRDLt4NGluRsvKpKaDxchjHkYjVnzYDZExbkFhrdewE4tkhslkiHgBMkKsq1Xr+HiGl/WwePa9PR07QVFkvfu3ZwEcCqrcHUBlzFrGcyC1zeH+lWLZCHe6eL1WE4ly2GBzQKc5EXXq6C3PYLGrEswe2VycvIeOrAdXZFEMt1mc2VrqWh5zvHCuwIM4fMr/VpjzAvYGhYvRO/YOpCQ+zkCIjC6Gb5ouSQJZNrBIyHeWcHOgACgAbwfY3wIF+8Ys7YGK5zu9DEogkiiWn00AnDUFy2XxvQmHoXYrGx9keeKAoBtXbpC8jrceceYNdMGCQDjWYtkAURSiodJbofb0RVeHdMOHrz5cHLfxAoz0TA+Pn5fwjt88UzUGLM8OyOgR5HJNXS4nRVin5kJX6Hb0ZXF+LIOHm8tYGXFAM2zW//Zw2nMGgaz0vnZqZ6ObwOZd5HMJkZf5nVbHlo6eISVrokY9FlJDbixhDFr5Hd5upPb0RVBJLOiHQSI+7xuy6GPqQXyndUacIhbPhB0HemDSe8wGNP2YBYrrkC3SK4j27e/1C9gr9vRlSI6DZIajMmZxyPWF/4+rNWuTgP8UrYN7+eSxrQ5mKXCaQ9F/jNJJMnCHhLD9oNlEEkC0k2gcnkVIrm4bgn8lofVmDUJZusx0dlV2qlFcj1EUoEHyLAJbkdXeOMjAZGXarWrtVXOpbK18R8l1fFiXXuMMc+3sDubk3jVA1GE7UvpdUczpTK+M2g+a175nKbnJTfxfUAXMr31c0lj2hLMEiLGb98+Pmnfm2+RzI4L8LjXbXkg23LtjgCEsbGxBwJ+288ljWmz34W+APx6He5qlVuRXGxHJ+AVLb1mCrzWJCCK59q4RsCoX4fXhzHtNVbyi7ar/Isk+vvnh0iMwO3oyhCdEor3FXj+8Yh1tRFv+LWoWHPEa0xbg9mzHooCiKS0MAqwz9NUBpEkQI5t7+aVNolkBMBabfwyhc/4fklj2hPMSvF+DAuX22SnFsk1nbGQHGHq/RrOJIttfEwb0F0YGxt7iPbdTZeuX+pXPMTGtEEkSZC8uSWE6xbJIohkxAmv2/JA4FRmdKFtRg1AjeTXfBTEmDYEswAgnZ+YmJhFB1+0XASRjABA4lWv2xJZoPBOu78lAMzsGXhHwHvecjWmLeHs1SIkUZ0skgSggYGBXkGHs3Z03motsDYiu2i5QV5ci++NU6fmCfxCq3AaY1bke4GAz3oo8i+SqHPTEYJ7Mp9nkSy+Vt6tAFdadwraSQPx3/tWEGNWpweSGhF430NRAJGkGqMkK3A7uhJkkoTA63fvdo+vwfePADA7vfUtAKdA3wpizMrsFAA01XgU1yyYtUi2c8Yijz4+eaaoxkcClE4DVx6h/ecZ0y1XXHkExE/Ra8aYFdopAfHqgwd7Jz0c+RbJdH+ViyJpymCBIbzfulOwFmsmgP9aio9S0bRQGvPCmSRxBnhrAW7OkVuRbG6VEcKhNXSqZn3nFGzg1Br+jAiA09O33xfwGZKCt4qMeXGllE7Z7+Y/k0RPz66dAvbLcUwZotOgGOfJuJqLlpe7liPEn8kM3EZuzAsGsyAueSjyn0kiBOxruWjZzq7QIkkIGG80KjfWWCQFAAtJ/WcV4wS8XWTMiwWzio8YK6fW2E4tku0QSSbxdZJpZmCRLLTxkQDJK/fu3Zxe458VAYSHk5M3Rf6SGwsY82LBLMSrW7fqrEUy3yKZzo54zBNVKq5g9RctLzvISsCfhCT4zKQxyw5mAVwcGxt7ALejy7VIZu3odMRTUyobfLtVxNZ6/UxP9/ynCHyRPjNpzAuEmDqX5+TJItmMXkZGtkI47IuWy7O+IuKpdfp52ZnJ83OM+uctrxljPtr3AsB7Hor8iyS2zy7sFvCyL1oufvoIgDHGB6ijXRctL/fnIoTkU1Kcgs9MGvNcHZAkRJ7zUBRAJFGpHCLDtqaT9RQVWCRJELi6dWtycx1FMgII09NjVyH+jAt4jHl+UCnpAaAr62inFsmVimQATmYPke3YCm582cGri+Pj4/exvsUAqTIG/Lgkdw8x5nnBLHl++/ZNYxbJfItkKoqKb3paShWmnt6AtdYAwHtT458T8GkX8BjzvGAW71y/fv2hA8r8imTTiSUijrRmA6bgkGc3cG1HRv2Ii8CMeW4w63Z0BcgksW3b8A6Ku3zRchlsLr1oOah+aoPeQwTAWu32L0Lxc1lzioanxpgPJSgAcNFDkf9MEpUtYQ+IIWf7pdHK6bkQL7YI53oLdQAwD/JHHSUb83QbkTQXpNMbZKcWyRcRSTXiIV+0XA7jIwmJlx9OTd3aQONLs8nu8NMxxvf8bNKYJ0WSkHC7Xl/XCnSL5MqnTG5HV54IFSROI93i3KhigDSbHBt7APD/gNttGfNEMAsQGpudHZuy7823SDY7B7ziKSmRBebjbroIgFT3v5R0EUuN840xAEScwlJvZZNDkcy2wEY3izzmop1SQAGgwpmcBGChVrs6Lejv02vLmMdFQHwrB8GsRfI5Iolq9eFLEPb7DsniB6YAAqQ6wEutOwUbnU12V/QTivqAziaNaRbtQMIpD0cBRBLgKIkeeE+8BHkkIehmjLycE5EUgDAxMTEbwb/tCTImtVQJM1K8mhM7tUg+J+c/3NJn05lkcYnZ5F2+d+/mZI6MLwLgvZ09P6MYP+9s0nR8JkkC0NWZ/q3XLZJFEEngVU9HiUJU8P3sj0lunAIQcP78XAR/QJIF0nS0SDI11LO4cuURXPmda5GMWVhz3NNRpjBV7+TwbTUAhHt3x39B0C+6C4+xoeJCDhMmi+RjCQeganW0D8IRpaWtnqyCrylJYOTp3Ca5ABDCD6TXAzmCNh1JmkgGfuChyL9IQpo7RGLY01GCuDQ9/lEDlNdigAaAZGby1ucB/Z9+Nmk61E6DpAU04ts5tVOLZKtIhhCPkdwEF+0U3/hIUBrL+d10AsCFJP7dGHUjswMLpekgkSQk3ZLmXNmac5FsctATVQ7jy4oBzmV30+V1KzMCCA/u3Bkj9b9kPV2N6RhIAOSVmZmZaY9GvkVSqWflIU9FqXgvZ0HYM4WyNr3zn0fFT7uIx3RWJgkAOoOl23KcoORQJBcvWoZwqOU1U+AAFQBiMTp4ZE7h1Dxj8t9LMc+ZrzFrYKw6Y7+b/0wS27e/1Cdgb1bZ6skq+HqS1EDA+ceFKNfZZFKrjb0F4YddxGM6KZileNZDkW+RDABAzu1vqWy1SBYXAQSEO1vmkJeercsVyrCpS38rSu+QTCyUptx2iiDFOUlXCmSnnZtJkpVX7JjKYXxp+Yuu3r5/e7JgTgMTExOzoP6qpHr2mh2HKW8wC16u1SpnLZIFEEkEvemJKk2ECgAXAdRRrGKACCCZmbr9KxL+kYM2U/ZgVsBpYOwBXLSTa5GM2ZS5srVERKrZaadoW+cRQOhK6j8Yo962UJpyS6XOFdROO0YkCUDDw8PbAB2QJ6sMUAJC5JeKnAlPTk7eU9CflzT3RIZsTHmMNeS2baRFsjV6ub/AvQL2wJWthY9L07UU50JxKluflU0m96Zu/46EH3C1qymhnSaSGkHxjIejACJJYT8ZtmaTZ5EstPERAsaAhaK3uYoAwszd8b+vGH8x23Z1kwFTJnOdfvQoXmxZ7yaHIpn98MarWUMwT1TBrY5Mz11NT0/XUOxD+c333Qhc+HMx6jrSOzG9Rk3xg9m0aufWw4f9kx6OfItk6ogUXvcUlAguFgMU/bqzCCCZnp6+KvJPI63WLXJ2bEwazAKQ8BZwfg6ubM2tSKbt6L4GFREnW14zRbdAsUzPORoAknvTt35J0g/6+aQpTzqJd+x38y+SGDw1uJPAsNvRlWMdSYLYOF+yz5Wen7x7/O9E6Wf9fNIU304BEOc9FPkWSQDAXEz2ANjhKShDYJpetBxi8kHLa2X5bAJ+vR4X+GcU43s+P2kKbaeKDyN5oWR2Ws5MElGHSFbgi5YLb3wkAelarbZ9rITGFwEks7O3JqD4JyXV4EuaTRFFkgTJsU2Yv26RLEAmCemoJ6o0ESpAni9xMUADQFKr3fmCGvjTaeLstWsKFsymSnllenp6xolJvkWy+RDyuIe/PHDpouWyGl8DQDIzM/7Tgv5HF/KYYhKvwhct51oks4uW3+wSeazkTrWD9BEQ9EEneBgAycz0+N+V4j9xIY8poLH+lkch/yKJ3t6roxAOurK18GR306mhpWKAsn/eCCDUpm//xSj9XCaUdS8Fk/N1m0iKEXjXw1EAkWQXR0n0wO3oymKDd7tQudFikGV3OABQZ+z+U4rxc1kBmjNKk387Zde1DrHTwopkOjsRh5n2o/MznYJbXTaPl6ambox3kPGl2WTt6vR86PpWSV/y1qvJu50KvDI1Vb1tkSyASBI44aEvU1bFMwAW0FnFABFA8nDqxnVEfaukcxZKk2c7pXQOODUPF+3kWiQjAEh4xUNfKjq1zVV2NOT2RSp+h6SrbjZgcgt5ukPttDAiSQDq7++vgjggebLKsH4EIAqnOngMGgCSu3cnvqTAb5d0x8dDTC6JuOxByL9IQqrsI7h76bikKShp0VWMjxQ6vs1VA0BlZvLW5xoK3ypp0kJpcmSniaR5IPlih9tpMUSyAbzhdnQlMT4SIK9vwvwNGx/qAJLZu2O/0VDjW6XYzCj9jNJssEgSgm6E8PCi7TTfIpn+QIZDnqhyGF92s/KVqampZpurTp/TRiqUdz4diT+kqGsu5jEbbqdpKnI5uxDdvjfHIpldtKxDHvby0NKOLng0loTy3tTt34Hit0i6YKE0G26n4jnbab5FMmtHhwTAgZbXTPED1VOez6cKZaVWm/hirDe+UTG+b6E0OQlmbac5ziSxdXBwEMA+t6MrvjIiLQYAFU4/tlNgmtQBJPfu3TmXhK5vkOLn3cLObISPl4AY4hkPRf4zSSQN7gO508NeGq28E0LiYoCPziiTqakb1+vz/GYp/kJLCzuPl1mPYJZSfBRZuWo7LYBIhoaOt1T8OZMssPFlba6uTk3duGXje65Qhvv3x2/Xpnu/PSr+WJZRymNm1sNOAVyY3QSLZM5FMvtp/LiHvDQRKihdQLp96DZXH01Mx+j83Mz07f9G0v+aBYvNZ/XGrJ2dAu9jbOyB7TTfIpm2owOPeshLBHm2dafAPNcGCCDUpse/X9CfAvAAPktp1nrhuR1d7kWSADQ4ONhD4WV5skohjwAQpdMeiheO7AUgqU2N/zgi/qAUL7ny1aylnSbSOQ9F/kUSc3PYJeAluLK1DI4+SGoE6b2W18zyxy87IjL+nxj5dVD8tZbG6B5L0047rcfYcDBbBJFEkhxioC9aLoXxEZBuSt0uBlg5dQBJrTZ+acvm5JsV9U+x9JzSWaVpj+sVbje2LFa2+vl3TkUy/UGMR+mJKoVIkoCIizMz16cskquiASCMjY09qN0d/3NIn1POePvVtM9ONX5/fPyOh6MAIhmF1zzcJYpRxQ+yPyYejdWZBpoFPVPjP46k8bWS3mrZfnVQaVYkklku+S4Wq6sdzOZRJJtbR5uIRZH0VmspTFDu4NFehxYBJLU7d94KmP86ST+aHhNx9atZVQj2tv1uATLJrVt37gCw3+3oyrFmBCCGcNZD0XYaAJLp6elabXr8L8QYvxPSDRf1mBXZqQQFfeChyH8miUqlsgdgn4e7FBkPEeN9Bbod3doJJQGEmbu3fwLSV0v4Bbqox7ygnUp6EJm4uK4IIolEB1uiYWeSRTY+EgCvzk5uumzjW1Mnl26/1m5frE3f+hYh/ncC7rUU9XjczUfaKcHrW5LGNdtpvkWyOTvHPVHlMD4CEHUeuPIIvmh5PbLKAAC1qdv/iDF+dZR+NRNKZ5XmI+0UwPmJiYlZ22m+RVIAECS3oyvTohFOr2eQ1eE0q1uTWm3iizPT438AUX8J0CQZXAFrng110Xaab5FsNm+uiDzmdnTlMLs0vQnveijWNzNoySobd++O/3AjJJ+E4qdAhpb+r84WzJKfJd/2UORfJNHbOzgKYb/b0ZXCUQdJDbBxoXWnwKxrVkkAyezk2Om70+PfJumPIuqct2DNE3ZaRyP5gu20ACKJJDlMshduR1cWG5yus+GKuXxklZyZHv9XsZF8Isb49wE8bLmr0luwHbs+CEm3YoSLdnIukk32p/d+2miLbnzZRcs3Hk5N3fZw5CKrFIDk3r2bkzN3b/8PiOF3Q/pZgGy53Nx213F2ChC8eu/ezWkPRwFEkojHPMylyWDSC1yBebjNVV5onqtMarWxt+5Oj38rYuPbJH0uzSr9vLIzlVJn4XZ0uRfJ5kXLJz3MJTI+LXbw8NZ5vgKYxS3YWm3iU329m786q4K98MTzSjvMjoBnbKf5FkkC0MDAQC+gg65sLYfVAQCF9zwUuWVxC/bKlSuP7t4d/+FYT74yxvg/A5iwWHaQnTL6ouUCiCSkyijB3a5sLUWmEhTjw0YSzrS8ZvLJ4hZs9rzyBxHxFRH6B9LiVVwWy5LaaYx6xIjzttMCiGQDPAmyC25HVwLjI0COdXPhuo2vMA6z5Xnl+OWZqfG/FuvhK6X4wwJqWTMCi2WZ5pwEoat3t1TO2U7zLZKpUkpv0BNVCuMjAQmXJicn79n4CimWAUAyOzt2ujZ9+y/FEL5KavwIgMmswKcplq6GLbKdpinKWYyNPYDb0eVaJJsTM+ohLhXNNle+aLl4xMfEcnLsdG369veqEb8yxvi/LV3JxQC3uis0BM+vRxJkkVzNHGU3GIA42PKaKb6f/ZLHoFxiOTMzcWHm7u2/vlBpfLmEvwroHMmQnbNsZqHORgq1deA7JIuQSWLr4OAgwL2+aLkc60QCKJ72UJRTLB/cuTNWm771DxMufBwxfmdU/DTSrgStzy2dXeZZG4FEkqjF4jqT40wSlUbYC2DQQ1wK46OgGkD3bC2vWBJAMjU1NXP37u2fmJm+/TVi/AOS/uViRayzyyIYa40MF1vm1uRQJAMAhMjj2ZaNK1sLbndM+wpertW2j1kkSx0MLYolAMxMTfxybXr8T6hR+bikH0LUqbTjnbPLHNvp1enprgkPR75FUmkIE0/aoZbGeQLABeD8HNzmqlPEEplYhnv3bpyrTY//zc3d+Ao04h+Oij8PYfYp2aUFc+Pt9O3sQnTbaZuorMH3TA2F/DIPb3kg5DZXnUejJZjm+Pj4fQA/B+DnBgZ2najH+IdB/hECr5JM0vIDNbv+BK+VjbBTnLKd5juTJACNjIxsJfSy29GViEi3uerg2cfjW7Gcmrp1aubu7R8a2rH9y0X9fkn/RIiXssrY5rnL6AxzPfURAHnJQ5HvTJIAdP9+/SWEMEK4srXgNCvm6jHIla1GT2aX58+fnwPwKwB+pVqt9sew+fcT+iYJXxdC2A0g60qp5h2XbPll2jcvQdI8YuJ2dAUQSaCCAxS3Z4ZhYyi+DU7HrsVGAjY+g5bskJlgolarTQO1fwXgX20bHh5K5uPXNYRvBfEVRNhLorkli5bM1ILZFpEkpTgeG/JFy0UQSYInszZmaVMBU1hHSDJRxIX7t8fv2PjMc7LLpmDq/vj47fvATwL4yZ6ekZ2VSuN3ifxmQX+A4GhWIYvsHPWTX29ecA5Sf8trs7NjU7bTfItkc2PlVTo2LJEX1CksHTz38yXzQoI5Ozt2B8C/BfBvq9VqH7D5DQV9LYSvB/UxMmxudR5PfA9nmsvNUIgLWLpo2XaaQ5FsnptKKJzwsi6T8fmiZdMWwUStVrsL1H4NwK8B+P7+/uFXIvSVEH43gE8COLiUZS5Kp0VzGUTh87bT/Iuk+vv7X4rAkWwbxVsnxabZju6sh8K0WzABNKanx98D8B6A/2twcLBnYUFfFln5PZDeBPQawX2LormknM1jJhbNpaIdBOmUl1r+RRJ1VF4OYJ8jmlIYH6X4qE63ozNrJpjNX5qYmJgF8OnsF6rVal8Im05GhU8K+i8IHoU0yhC6F7/ZUroZOzjbpKQH6qpctZ3mWyQBAIl4AIGUFJ1JFtyZkSRwdXOoX71v4zNrI5h6ItBu+oyYbs3iN7NfGBwc7KnXub/e0JuB+ISIr4BwkMT2Zrb5DOEss3g27fRGl+bcNrIIIinysC9aLofxEYCEC9lFy77A1axnlvmkaDYzzXezX/838GZXtXrtZQUcREMnFfgxQK8Q3AdwgFyqrG/Zqn2aeKLAAmo7LZBIKgvjjsKlraWBRLMdXXjCgRmzEaLZImZvLdRquIj0MvBfaa7T/v6RPQ02jko4APEwiUMQjgt6meSW1qzzce38SAHFU/6cn4GS7TTvItlsQdUloplJWilL4aX0vkfB5Eg09WzRTEVuenrsKoCrrV84MjKy9d489ib1xu4G9UoQDihgP4FdAoYI7AJCd2v2+UQG2vpSfIYP3DhBZTyXZxG3SGZs2fHyIOP8qC9aLgWJJAXfcm6KI5pPE04AiGNjYw8AnM5+/WrL34VqdW+1HuZ2B2BvQDwCcYeAE4B2EhgCMCChh+Tm7Pq/5FlvpuVfT75HrdHnh6Qo8gvNz+plkU+RDAAaXZo7CXAAS+XZprjOh4CmgMo1G58puHA+UzwBxFrt6jSAaaRHUX6x9YuGh4e3NRqN3jmpF+jqRb3xMhn2RKgKYj+FYYCJiG2U+gRWSW2BsB1kd1ZUs4a+kFBs3FY9OdcqnCanmSQijzKtbG3A7egK7WhIMgo3pqf7bwFjHhFTZvF8UkSb/2/Mrge7jyUj+NyzfsDIyMjWe/ewddOmuc1RyQ4o9DWAbYS2E9pOYZvIbkndJDdJcQvJTSB2Say0vI9AqPWqMSntzyoAdUI3Ac5IegggJoxfrM3edtvIIogkqSNOIEvjUADgMnBqHq6YM+Vf63pmqvZ0MdUT4qtsS/dB9vp1D61FEk9sWwDicWtkeSDwTvZHV8wZi+hzzeWZwrrcn/ECpvkhbJ85FkkC0MDAQG9dOpie2rFUFl8fAQGubDXmxYXOuy4loh0dcVKHqsoogZfgi5bLYOxB0gJjPG2jN8ZYJNsgkjHqKBm6sXT7uCmsSBKCxoD5yxZJY4xFsi3fiW/aoZZDJLOGSVdqtVrNw2GMsUiuOvMABB72cJYqnzyXzW3iwMcYY5FcGc12dAmhl1teMwWHDO60Y4zpeNpyBGTbtqGdEPfKIlmKwEkSxPiOh8IY40yyDV+fdHMUxKB35QpPdtEyZpHgYstrxhhjkVy5a9UhpNfPuLK16CJJgtT1me7uGxZJY4xFsg0QeMUXLZdDJLN5PIfr1x/C7eiMMRbJVZG1o8PrHsoyKSXPtjOIMsaYThRJAtDw8PA2kMeye0m91VoCKJ32KBhjzOpFEg8fxhFpsWjHIllsEklA5EUPhTHGtEEkSe4juR2+aLnoZM8eNRXC/PnsNV+0bIyxSK4GEiezNmZ2qAUXSZIQeHV6+rWbHg5jjGmDSEbwpIexPJkkpTPAr9ezteHKVmOMRXKFNACAwKvNpNLDWQqlfMfzaYwxqxNJAsDOnTtHQB2Q840ykD5jFk55KIwxZnUiGQCgXq8cBjiU7cr5TF2hE0gExfgoBFxoec0YYyySK6UB7GVateOincKLJCFgIsbN1y2SxhjTBpEMahyyQy0HJBCIC7Xa1Rr8PNIYY1Ylkll/HR73EJYlkwSieC7bFXBlqzHGrFAkFy9aFnm45TVTfKV8z6NgjDGrF0lsGdg9Qmif5HZ0ZVgHkhCCXNlqjDHtEMlNjfphgH0ewjIkkKCEe2j4omVjjFmtSKYkeoNpaWvDmWSxRTKdRt3YujW5ZZE0xph2iKQWn0ea4meSIHhlbGzsAXzRsjHGrEokmxctH/DwlUop31914GSMMR0ukgSgwcHBHhAHfNFyKWi2o3vXQ2GMMasXSTx8WNkj6WVftFyGBBJBUiMmOu3hMMaYNohkktRPhBA2I916tUgWXSmlcc0H92w1xphVimTqRZm8YodaCiJJELw8O3vrTvM1D4sxxqxMJLOnkPHjHroSQZzP5tZFO8YYs0KRTNvRHTrUDXC05TVTcAR84Pk0xpjViyT6Jx8MEdrtdnTlmH8BiNFFO8YY0xaRlOJ+gAMeujIkkKBifMCueKrlNWOMMSsQydSLMh5xO7qSiCQJkjc2kzctksYY0waRJHjSw1YOkUy3BnBhYmJiFm5HZ4wxqxLJCIARes3DViql/GClAZMxxlgkmwkkoG3bhgcJnsyKduxUyyGTZz0GxhizepFEpdLYA2CHh60ccy8BaOCCh8IYY9ogkkjCKMkK3I6u8OkjAEJxrpFwrOU1Y4wxKxDJ1IuKR+1QyyKSBMjrm0P9iufUGGPaIJIEjnnIyiGSTGtZL05OTt6DK1uNMWZVItlA2p3loIesTErpi5aNMWa1IkkA6BkZGYBw0JWtpSC9aJl4z0NhjDGrE8kAAJWHOkFiuNXJmuKKpKTIGHz8wxhjVimSGY19JAN832DRSStboekQ5i61vGaMMeYJKsv2rAwjTJ2pHWp+xG45r7PldwFokEyi9P7U1FSzZ6sDH2OMWZVICoHM7pT8cAbq7df1EUUtZYLP3AUgyBap1BMZJJtz/k+zuUyQFmYZY4xZgUimF0dKn5UwR7I7K955VgajZWY8T3fwa/P/buT3XE2G2PrnAGT3rwCQJEgPBdZBiFADQEPAQ0bdF7lAoEfCEIme7LPVhXgN0j+ZmZ74qew1C6QxxrRDFLZXh787EP8tgH0CqqQ2ZZnJUlaTpZtrohxaqfauWKTW5Qc+MQ98MilcFEXonIDfJvFFRl5oME6GWJkD6o16YIOhsdAVNz1YWNDDECqNSuXB1gVU9gToJYndJCYqbJyanJy86aVvjDFrkDmNjIxsvX+//hK6kn7W1ROJHhLbFLGFQZtIbFXEFoTQRSkBVJHYLWILoc0EN0HqEpkASAAlFCoguwR1AUwgJIQCgERpG7yEUgVkRVAFQAIxIZCACs0sC+lZzgAhAApMPx/Bxb9v/YWn/Peyhobtyjn1pPIu/teCgAcEJgVdgfB5gZ/urjTeunPnzlgbfrILsIwxZg1Eci2da/M5W1gSrj1hcHAuaTQaodFoJI3G1mTLlnql0WgkUncSYwyAQowxATYFdcUgKXRJiVRJpJigoiApERQghURKgEoARCVKIAQhCZCSkCiBQgIgSLEiIQEUoJCEBAFSkopwCIASBiVQqABKJCVL48mYboGmzxDTr1HIMu1IsA7GuiIXSC2AXIhRCyTng/RI4j0yTs1XdPvBnTsTAOpPGaflZr2tQUDrc01jjDHtziSfkXnxGQ76o5z3cv5/sxScNIumPF7GGJNjkcyTWOdpDNpZoKRn/G6MMcYYY4wxxhhjjDHGGGOMMcYYY4wxxhhjjDHGGGOMMcYYY4wxxjyX/x+i5+k9cWHDzQAAAABJRU5ErkJggg==") center/62% no-repeat,linear-gradient(150deg,#FBFCFE,#D9DEEC);
+  box-shadow:0 6px 22px rgba(255,255,255,.12), inset 0 1px 0 rgba(255,255,255,.9);
+  animation:markIn 1.1s var(--ease) both;font-size:0;
+}
+@keyframes markIn{from{transform:translateY(4px) scale(.82);opacity:0}to{transform:none;opacity:1}}
+.brand small{display:block;font-family:var(--font-body);font-size:10px;letter-spacing:.24em;color:var(--faint);text-transform:uppercase;font-weight:400}
+.navlinks{display:flex;align-items:center;gap:34px;font-size:14.5px}
+.navlinks a{color:var(--muted);position:relative;padding:6px 0;transition:color .3s var(--ease)}
+.navlinks a::after{content:"";position:absolute;left:0;right:100%;bottom:-2px;height:1.5px;background:var(--edu);transition:right .35s var(--ease)}
+.navlinks a:hover{color:var(--text)}
+.navlinks a:hover::after,.navlinks a.active::after{right:0}
+.navlinks a.active{color:var(--text)}
+.btn{
+  font-family:var(--font-body);font-weight:600;font-size:14.5px;
+  border:none;cursor:pointer;border-radius:999px;padding:12px 22px;
+  display:inline-flex;align-items:center;gap:9px;transition:transform .25s var(--ease), box-shadow .25s var(--ease), background .25s var(--ease);
+}
+.btn-gold{background:linear-gradient(135deg,#F0BE54,#E5A92B);color:#1B1404;box-shadow:0 10px 30px rgba(229,169,43,.28)}
+.btn-gold:hover{transform:translateY(-2px);box-shadow:0 16px 40px rgba(229,169,43,.4)}
+.btn-gold:active{transform:translateY(0) scale(.98)}
+.btn-ghost{background:rgba(242,243,247,.05);color:var(--text);border:1px solid var(--hair-2)}
+.btn-ghost:hover{background:rgba(242,243,247,.1);transform:translateY(-2px)}
+.nav-cta{display:flex;align-items:center;gap:14px}
+
+/* ============ LANGUAGE TOGGLE ============ */
+.lang-toggle{display:inline-flex;align-items:center;gap:2px;padding:3px;
+  border:1px solid var(--hair-2);border-radius:999px;background:rgba(242,243,247,.04);flex:0 0 auto}
+.lang-opt{font-family:var(--font-body);font-weight:700;font-size:12px;letter-spacing:.05em;
+  color:var(--muted);background:transparent;border:0;cursor:pointer;padding:6px 11px;border-radius:999px;
+  line-height:1;transition:color .25s var(--ease),background .25s var(--ease),transform .25s var(--ease)}
+.lang-opt:hover{color:var(--text)}
+.lang-opt.is-active{background:linear-gradient(135deg,#F0BE54,#E5A92B);color:#1B1404;
+  box-shadow:0 4px 14px rgba(229,169,43,.28)}
+.lang-opt:focus-visible{outline:2px solid var(--edu);outline-offset:2px}
+.menu-btn{display:none}
+
+/* ============ HERO ============ */
+.hero{position:relative;padding:96px 0 60px;text-align:center}
+.hero-glow{position:absolute;left:50%;top:120px;width:680px;height:420px;transform:translateX(-50%);
+  background:radial-gradient(closest-side,rgba(229,169,43,.22),transparent 70%);filter:blur(8px);z-index:0;pointer-events:none}
+.hero .wrap{position:relative;z-index:1}
+.hero .eyebrow{margin-bottom:26px}
+.hero h1{
+  font-family:var(--font-display);font-weight:700;
+  font-size:clamp(38px,6.4vw,76px);line-height:1.04;letter-spacing:-.01em;
+  margin:0 auto;max-width:14ch;text-wrap:balance;
+}
+.hero p.lead{max-width:62ch;margin:28px auto 0;color:var(--muted);font-size:clamp(16px,1.6vw,19px)}
+.hero-cta{display:flex;gap:14px;justify-content:center;margin-top:38px;flex-wrap:wrap}
+
+/* ribbon hành trình */
+.journey{margin:62px auto 0;max-width:920px}
+.journey-rail{display:grid;grid-template-columns:repeat(4,1fr);gap:0;position:relative}
+.journey-rail::before{content:"";position:absolute;left:11%;right:11%;top:26px;height:2px;
+  background:linear-gradient(90deg,var(--edu),var(--content),var(--space),var(--care));opacity:.55;border-radius:2px}
+.jstep{position:relative;text-align:center;padding:0 8px}
+.jstep .dot{width:54px;height:54px;border-radius:50%;margin:0 auto 16px;display:grid;place-items:center;
+  font-family:var(--font-body);font-size:13px;font-weight:700;color:var(--text);
+  background:var(--surface);border:1.5px solid var(--hair-2);position:relative;z-index:1;
+  box-shadow:0 8px 24px rgba(0,0,0,.4)}
+.jstep:nth-child(1) .dot{border-color:var(--edu);color:var(--edu)}
+.jstep:nth-child(2) .dot{border-color:var(--content);color:var(--content)}
+.jstep:nth-child(3) .dot{border-color:var(--space);color:var(--space)}
+.jstep:nth-child(4) .dot{border-color:var(--care);color:var(--care)}
+.jstep h4{font-family:var(--font-display);font-weight:600;font-size:18px;margin:0 0 4px}
+.jstep span{font-size:13px;color:var(--faint);font-family:var(--font-body);letter-spacing:.04em}
+
+/* ============ SECTION SHELL ============ */
+section{position:relative}
+.section{padding:96px 0}
+.sec-head{max-width:760px;margin:0 auto 56px;text-align:center}
+.sec-head .eyebrow{margin-bottom:18px;display:block}
+.sec-head h2{font-family:var(--font-display);font-weight:700;font-size:clamp(30px,4.4vw,50px);line-height:1.1;margin:0 auto;letter-spacing:-.01em;max-width:20ch;text-wrap:balance}
+.sec-head p{color:var(--muted);margin:18px auto 0;max-width:60ch}
+
+/* ============ NORTH-STAR DIAGRAM ============ */
+.eco-stage{position:relative;max-width:980px;margin:0 auto}
+.eco-svg{display:block;width:100%;height:auto;overflow:visible}
+.node{cursor:pointer}
+.node-hit{fill:transparent}
+.node-core{transition:transform .4s var(--ease), filter .4s var(--ease);transform-box:fill-box;transform-origin:center}
+.node:hover .node-core,.node.is-active .node-core{transform:scale(1.13)}
+.node-label{font-family:var(--font-display);font-weight:600;fill:var(--text);font-size:18px;text-anchor:middle}
+.node-sub{font-family:var(--font-body);font-weight:600;font-size:11px;letter-spacing:.12em;text-transform:uppercase;text-anchor:middle}
+.node-num{font-family:var(--font-body);font-weight:700;font-size:14px;fill:#0A0C14;text-anchor:middle}
+.path-journey{fill:none;stroke-width:2.5;stroke-linecap:round;stroke-dasharray:1;stroke-dashoffset:0;
+  stroke:url(#journeyGrad);filter:drop-shadow(0 0 6px rgba(242,243,247,.18))}
+@media (prefers-reduced-motion:no-preference){ .path-journey.draw{animation:drawJ 1.8s var(--ease)} }
+.spoke{stroke:rgba(242,243,247,.13);stroke-width:1.2;stroke-dasharray:3 6}
+.tech-ring{fill:none;stroke:var(--tech);stroke-width:1.6;stroke-dasharray:2 9;opacity:.5}
+.core-badge{filter:drop-shadow(0 10px 30px rgba(255,255,255,.18))}
+
+/* panel hé lộ thương hiệu con */
+.eco-panel{margin:26px auto 0;max-width:720px;min-height:96px;
+  background:linear-gradient(180deg,var(--surface),var(--bg-2));
+  border:1px solid var(--hair);border-radius:var(--r-md);padding:22px 26px;
+  transition:border-color .4s var(--ease), box-shadow .4s var(--ease)}
+.eco-panel .ph{display:flex;align-items:center;gap:12px;margin-bottom:14px}
+.eco-panel .ph .swatch{width:11px;height:11px;border-radius:50%}
+.eco-panel .ph .stage{font-family:var(--font-body);font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:var(--faint)}
+.eco-panel .ph h3{font-family:var(--font-display);font-weight:600;font-size:21px;margin:0}
+.eco-panel .pdesc{color:var(--muted);font-size:15px;margin:0 0 16px}
+.brand-chips{display:flex;flex-direction:column;gap:14px}
+.brow{display:flex;gap:12px;align-items:flex-start}
+.brow .cdot{width:8px;height:8px;border-radius:50%;margin-top:7px;flex:0 0 auto}
+.brow .bname{font-weight:600;font-size:15px;letter-spacing:.005em}
+a.bname{color:var(--text);text-decoration:none;transition:color .2s var(--ease)}
+a.bname:hover{color:var(--edu);text-decoration:underline;text-underline-offset:3px;text-decoration-thickness:1px}
+.brow .bdesc{color:var(--muted);font-size:13.5px;line-height:1.5;margin-top:2px}
+.eco-hint{font-family:var(--font-body);font-size:12px;color:var(--faint);text-align:center;margin-top:14px;letter-spacing:.04em}
+
+/* ---- mobile vertical constellation (phone) ---- */
+.eco-vertical{display:none;max-width:440px;margin:0 auto}
+.ev-core{display:flex;align-items:center;gap:14px;margin-bottom:6px;padding:15px 18px;
+  background:linear-gradient(150deg,#FBFCFE,#DEE3EF);border-radius:var(--r-md);color:#0A0C14;
+  box-shadow:0 14px 38px rgba(255,255,255,.08)}
+.ev-core .ev-mark{width:46px;height:46px;flex:0 0 auto;border-radius:13px;
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAckAAAIACAYAAADpMJeQAABEsElEQVR42u29ebCdR3qf9/S5ALiBK7iDJAASO8BlNNQyykiytThabCXREi8la4lTkWWXLCfeVLGiWIplLZGrFJVKclKJJpKsaIs1snZLkSWNrNFsHG4g9p0Ed5AECYIgiHs7f3T3fB8O7wXucu4939fneapOnYuDu5zT3W//+u1++31BREREREREREREREREREREREREREREREREREREpJ8Em0BEpA5ijGGe8/x85v64TLoSL/daCCF2qU0VSRGR/gjfXF/HLDAzFXzeQfuf4xZNRVJEZBGCNYrJu/X7hp/jYkUixrgauGqWx5r8uBq4Bri29Sj/vzo/r8qPqdbzID/a77E8ZoCLQ4/3gAvAOeAs8DbwDnA+P97N/z5XHiGEc3O0URiXYCqSIiLz9HDanlr2eEIRiitN4EOCWCb9mfn83Sxqa4EbgJvz803AbcDtrdduBtblr6/Lgri69SiCt3qM839bRM+3RPJN4BRwCHga2AscCSG8OR/BbP1f4P1buqEl6Ata4CiSIiIL8/xuBM7MMkkP5phXLyuiMcabgDuBe7Pg3ZGfb2mJ37r89dqW+E2N4iMNPc/1/0t1vsIi9OYN4DDwGeBjwJ+FEJ6bRRSLZz+zkH6cr1AqkiIi8/AgY4yPAP8KuA84DjyWH08CJ+fhSa7KYrce2ALsBHYDm4G7sygOFihwcQ6vab7z/EprQLzCa7ElqMPv7RDwe8BvAY+HEE4Pte8UsBHYkfvo+vy4CLyUPdO9wKt6kiIioxfJjwL/5SzfcgJ4AtgDPEc6f7tIOue7Ebg1C+N9eRK/M3uE8xW++QTuVNn0rXZoi+ZF4EBeoBwjbdXeDGwHHs1tPVvbvJu//1ngh0IIfzq8ha5IiogsTCBDCCHGGG8GPpuFbqbl8Q0W+6tbj7YAOCfPzcwC2nw2D7v9cz8VQvju+YjkKttdROSyjkQkbeHdSxPdGeaYjGc7j6Qlhm2vSEFcGIM5FhizOX5hjr64mH/P2fkuShRJEZHLiyTAw6RAmWkuDZi5ktgphMvTJ2GRPzfI/ffaQpVZRETm5mGboKpFzylFUkRkqTNqCNP5qsEOW6P3xKx57wH7Wq8pkiIiC55Rm8v/t5KubDhn1sFp4EVFUkRkaZT58X5SZhvpvydJFshXFzoIRERkdnaQghynMRCnBpE8FkJ4L1//0JMUEVkiW22Cqvjz/DyvBY8iKSJyec9ji01RBUXv9izmh0REpKhjyrQzk8tObVqI5yGdXfAEUgq7E0OLIEVSRGSR3A5sUCSr2RU4DpxUJEVElkaZGx8gVeeQOkTyaAjh3EJKZSmSIiJzsyXPkzN6klVwZKHap0iKiMzNI0OeiPSbowv9AUVSROT9zOSMO7tsit5T0tFNk8qdLWjRo0iKiLRn1Oa86gaMbK2FQMqyc0iRFBFZ+oQKcBdNOjpFst+eJKTKH6cX+sOKpIjI7CJ5P3Adsxf3lf6J5J4QwsX5pqNTJEVELk85j5yxKargmcXsCiiSIiKzex4P2hRV7QwcXswPK5IiIkUdL01Ht2sxnod0bsEzAC7QXP9Y0HUeRVJE5P1ex52Yjq6mXYFjLU9SkRQRWaJIbsB0dDWJ5MEQwtmFpKNTJEVE5ub+LJimo6uDo4vVPEVSROT9PDjkiUi/dwb2LvYXKJIiIg3lusfDNkXvKUE7EdinSIqILGVGzedVMcbrSdutbU9E+ssZ4NnF7gwokiIilwriBmC9IlmFJwnwCvCyIikiMhqRfAC4GtPR1SKSexZaaFmRFBGZG9PR1cXjS9E7RVJE5FLPY4tNUdXOwKGl/BJFUkRUxyYd3QDYNjTJSj8XPAPgPeCIIikiMhpux8jWmniJlJIOFrl9rkiKiFwatHObzVGFJwnp6sdrepIiIqMRyQfzvGg6ujpE8mjZRl9MZKsiKSJyKduGJlnpN58ZWgQpkiIii2BmSCSl317kVH5+fKm/TJEUkcmeUZt0dNcAG5fqeUhneBM4udSdAUVSRCadIojrgXsVySo8SUhBOy8qkiIioxHJzcBaTEdXi0geDCG8s9h0dIqkiMilbM/PpqOrg2Oj0DlFUkT0PBKP2BRVcWIUv0SRFJHJVccmHd0UsCO/7FZrvyn3XPcqkiIio+EOYJMiWcWuQABeBfYM7RQokiIiC6Qd2XqLzVGFSELaan0VIISwpDNmRVJEFMlUHmsK09HVIpKHQgjTuarLklAkRURg99AkK/3miaFFkCIpIrIIylbcLpuiCoqmHRj1LxQRmSha6eiup7kj6VZrj7s09997NNc/lrwzoEiKyKRSBPEeTEdXi0gCnCKlpBuJSK6yXZd3pTqrZS4hRZKIjFwkNwPXYDq6WkRyTwjhtaWmo1MkV0AgL9dBWUDbj3YnX/KsqIosK1vy8wwpwlX6zaH8PACmFcmuLlHTWcd1wFWkPfK32/d1svDNW/xyKHMR1LaIKqQiS/M8DNqpa2fg4Ch/qSI5eg9ykNNcPQz8MqmqwLvAmRjjTBbMi/n5OGn//ALwDnAYOA2cB97Ij3MhhHNXuhCbPdPBLJNAVEBFZl3IzsQYVwE7bY0qGOQ5b+8of6kiuXyrmQ/RRMwtZoX7Vn6cjTE+T8oe8QJwhlQj7Zn82rNZSC/OtbXQ8kIVTxEuOQ5ZR5OOzkDGfu8KhDw/Pje0U6BIdpSdpDOOad5/zhFn6dwisEXQbsgPgG1z/I13i3DGGE9mr/RQ9lBPk8KgT4UQ3puH96lwyqR5HdPAA8CtQwtc6a9IvsIICi0rksvLTPbcdrfc/8EiOny252EjvwrYmP/98Czf8zpwKsa4HzhJ2qv/nIiGEM7M5n3miggKp0wCW2nS0elJ9p+TIYRzo4psVSRHvZRpLiffTLPVuhjDC/Nc2cY5hLQE+NycH7uHfu5N4I0Y417gceBp4AhwLITwSghhWo9TJoRdo/Q6ZKyeJMBfDO0UKJIdo0Se3sPKVBQIVxDSOCSk5FVz2cq9D/jq4gEDL8QYj5Aqen8C+CxwOITw2vCAa51zKprSR0og3Dabopq5F5ryWCNDkVyejtpC2god9xbOXCI6LJ7FU1yfH18KfFt+/8/HGA9kwXwG+BQpw/5FRVN66XI0Oz7XkBIJgOeRffciS6Hl44pkP9gytAXQRTEP8/Q678mPr8ivvQPsjzE+CXyStF17KHubiqb0ZTEbSanoTEdXDy+SdsHaOwWKZEfZ2tOJYz7CeQ3wgfz49vzayRjjx4E/z8K5L4Rwdkg0SzDQjIIpHRjrkOIG1mI6ur5TMiUdIxda1pPsor+fgltKZOuWSlan8xHOKdLZ5n3A3yAlSjgRY3wM+D3g49nTnJ7Ny1xq1XCRJfDQ0CQr/eZIThAxGOW8okiOUlHSOcc60t2rmlfh4TKiuSp//geA/xp4G3gqxvhJ4A+AT4QQXh9aXJSrMm7LyoqsafOzQTt1cXg5nBNFcnSUkOMdwB0s7n5kbaIZgOtI2Yc+BPxD0tbsJ4H/CPxpCGEfrcjZvC2rYMryqGMK2pnJ42yLLVLN3AvpqGfkKJKjZ1NLMCdxC+dyojmg2Zr9ZuBcjPETwH8A/hB4uh01q2DKMnJzHodgEoG+7wqUdHSHhnYKRqrAMjq22wTvE81BXjAEmlR908C1wJcDPwp8GvhEjPGfxxgfjTGuCiFMhxBm8jb2VD7LFBnFnLcBuM3mqEIkIUW2vrQcIqknOTq8nLzwhVlstdsU8MH8+BfA0zHG3wF+HXiiBP60zjCNkpWlsDvPf6ajq0MkD406HZ2e5Ch7qbmcvIbm+och5fPzMqfyI7a8zFWkKybfR8r887EY4z+LMW4JIcTsYRbvcioLp8hC2LkcXoeMjYPLpWmK5Ogme4C78XLyUtpwMItgrgE+DPwI8FiM8TdjjH8nxnh3Fstpt2NlAcy0PEmphyPL9Yvdbh2tSD4A3IiXk0fRnqG10i+P64G/lh8vxxg/Cvwa8GchhAvZqy93MN2OlUto7fisxR2fWigL42PL/QdkNHz+0GpVRu9hlqCf24HvBP4/4FMxxn8UY9yUA33a3qWToAwvZu8j7fookj1f9+T+e5VUyai8pkh2tLOgn+no+jbJTQ0JJqRamj8OfCbG+Msxxq/MWTfcipW5RPJa3PGpZd49AjyvSHa1l5rLyQG43xZZccEsnvs0qTzZXyfdufxPMcbvjjHeUa6SxBgHiqXQRKC741OJSLbS0SmSHeZG0t0rXJ2uOINZvMsPAT8JfDrG+MMxxofyVuxMjDG4FTvRk+pDNkVVPLOc864iORqPBlI5qbsUyc55l/cC3wt8Msb4czHGD89yjcT+moTB0ez47NBOq1kcA+xdiT8iSxfJzTSFljW+7niXRSyvBr4V+NMY4x/EGP9qK6uPYlm7C9lss99JSh2pSPZ/VyAA79EUWo7LNZHIaERy13J2lCxZLMtW7AD4KuC3gD+LMX5rjHGNYjkxdrqRFBmtSNbBG8ALimS3KYf/n2dTdH6SbItlBL4I+Dngz2OM3xFjvFqxrJ5ted4zaKf/niSkrdZXliMdnSI5il5qIltXk7ZbXZ32RyxLsvUZ4FHgZ4GPxxi/PcZ4bVssbbKq2LKcXoesuEjuyQWWl03LFMmlT7iQAnbWK5K9Y9DyKmZI+WI/ksXyb5YzyxINa3P1muI5WqWnLvatxCQhSxfJ+0h39BTJOsTyYeD/IZ1Zfn2JhvWeZU9djiYd3VWYjq4mm4WmhqQi2XE202zfST1i+UXAv48x/k6M8cta9yw9r+znYnY93mWuYt1DU2j5cOs1RbLDWHanXrGMwNcCfxRj/NkY427PK3srkltJSfJNR9d/kYQU1fqiItltiuf4oE1RrVgGUjTsFPAdwF/EGH8gxriudV6pHfVrMeuOTyUiuVyFlhXJUfRSc85xE00uSNuzTtpXR9YC30/K4PMt8LlMLm7Bdn9StYZkXTy+EvOuk/riaaeju8fmmIj+bovlA8AvAP8hxviFbsF2ejFbPEer9NQ1935mJf6YIrn0jtoMrMZzjkkTyxLc81XAH8cYf7y1BWsUbPfEch1N0I590+9dgUFeqB4a2ilQJDuKZXcmk0HLWK8B/hGpPNc3t6NgbaZO9BOkJAJ32RzV8DLwrJ5k91c00ORslcmkvQW7HfjVXPh5k4E9nWJn7qtp3PHpM8UZOQq8AikmQJHsIKXIJ006Opng4cClW7B/nZQP9ttzIgK9yvFjBHpdHGrNwXqSnXMhmyjG20gBHLallDFQtmDvAj4SY/zVllc5MAJ2bJ6H6ejq4uRKzbtO7Etrt63AOkwiIJdStmBngG8ml+TKZ5VGwK7gYja393VYQ7IWSv89U7pZkew2u2i22TQ+GTbm4lWuB34uZ+y5I3uV3qtcuQn1DixAUMW6J9vUeeApRbIfeB4p8/Eqy1nldwAfizF+ZQhhOns72uDyi+Qm4Dq8plWDSEKKan1Wkew25Zxjm00h87Sz4lVuBX43xviDwMCgnhVhJxYgqEkkT4YQ3l7udHSK5GJ7qTnnuAa4f2jFKjIfr3I18D8BvxVj3Fi2X22eZeNhm6Aq9q2kfimSC6cI4u14ziGLs7lyr/JrgD+JMX51606lY2l0i9my+NihnVbF3pU2WFmcSG4GbsBzDlncGCoX2zdkj/Kf5juV0XPKkXIbTeyAdtr/BSY0NSQVyY7zEJ5zyNIo269TwI/GGH8hxniT55QjXcxuIl3Tkp5vDuQ+fQs43npNkexoZwF8nk0hI7TBaeBbgD+IMe7wnHJkInk/XtOqad7dDxxRJLvaS7nsTj432miLyAgn9LL9+vnAH7XOKb1PuTS2r+SEKssukgdKOrqViGxVJBfPzcB9QytWkaVShPIu4DdijN/Vuk/pOFvcpGoBgro4tNLzriK58BU/WSDvVCRlmYRyBrgK+OkY4w8DwYCeBahjs+NzNUa21jb37l3pP6zRLa6jNgNr8JxDls8uS+7X7wV+IcZ43UpVPahsMes1rTp2BQbAe6QSWe2dAkWyozy40h0lEznRB9L2698CPhpjvN3I1wWJ5APA9XhNqxZeYwXT0SmSi1/RgOccsnKT/RRwEfgqUjq7DUa+zpsStOM1rTrm3eeBN1b6jyuS8+2l5pzjmpYn6epUVoJVWSg/CPx+jHGnQjkvdtoEVYnkp0II78UYp1YqslWRXPiqHlLkoUE7Mg6hnM7e0e/HGD+oUM6+mAXKNa37bZGqeHIcf1SRXLhI3kdKR6dIykpTrojcC/xOjPFLs1Cusmlahpq8jBsxHV0tFJ06okj2gy35edqmkDEK5R3Av4sxflkI4aIe5fsWs5uAuxXJ/m8O5P57kxXOtKNILh5rSEpXhPJW4NdjjF+iR/k+kdxG2qL2mlb/RRLgOeAFRbLblAi5HTaFdEQoZ4BbgH8fY/xw9igVyoTXtCoTyRDCuZUqtKxILrSXmkLLa0mV5XF1Kh1gkIXyZlIauy9w69XFbKUcHZdmKZLzo51pZ4MiKR0UynXA/xtjfHBSo15bi9k1NLED2mkdc+/Hx2lgMv+Ouh9Yjecc0j2hLFGvvxZj3JiFcjChdnoXpqOrYt1Dk45ub+s1RbLD7BhXR4lcgRLMs40UzHPHBOZ6baejuxnT0dXCacaQjk6RXPiKBpo0VyJdFsoPAL+Uz9DjBJXZKp/zkfxsOro65t1jWSjHgiJ5pV5q0tENMGhH+iOUfxn43/NYDRMilEUUza1cl0geKMcHKx3ZqkgujNuBjYqk9EQoL5Kqh/xQCGEGGNQslK3FbMAakrVxaJz9qUhemXbQzu02h/TMo/zeGON3hhCmJ8TebyWljlQk65l7j47zTSiS82+jD+TnaY1PejLBlOLNPxFj/IrKr4YUm1xPStknPd8cyOP3HZrE5mMJmFQk59dZ0CRLFumTcETgauDnY4ybKr4a0s7Zajq6eubdZxljZKsiOT9KMMBWm0J6SLlDeTfwizHG66k74nXXOCdUGblIHg0hnB1HOjpFcj691GTwuBaDdqS/lPPJDwH/W55sarP9MoE+bHdXxf5xa5UieXmKIN5JymaiSEqfhfIi8B0xxr9f0/lkK7L1apq7zNppHXPvM+N+I4rk/DpqI3A9buFI/4VyBviRGOMXV3Q+2Q7aMbdyPXNvpLn+oUh2nN352WAAqUFM1gI/G2O8JTlivRfK9jWtspjVTnu8OZD77x3gVOs1RbKjnQXw+TaFVEIJ5NlGcz5ZS0ae7a3FrPR/3j3ImCNbFcnL9dKl6ei8/iE1UQJ5viXG+HcrSjSwxa6tSiT3hhDeHVc6OkVy/twC3JO/dgtHavIoZ4AfjTHu6vn5ZPEcd9qtVbGnC/OuIjk3pWPupcngoUhKbeP7BuCnY4xXQdpB6ZXL0VzTupnmLrPzWv8XcJC2WzvzZmTuSWQbFlqWeiejaeBLgX9SEqH31E7vwdzKNVCCds63RDKO20jk8mzvQkeJLOMcMENKhP5oD7dd24vZq1zMViGSAC8CzymS/eisB20KqZhyH+064Kf6uu3qYrY6XgohvA4wzqAdRXIudWwiW6+jyQXp6lRqpUS7fiHwD3u27VomUAst1+WcPJbn4rFnhVIk515dQ0pHZ2SrTAJl2/Wfxxh39mHbtbWYnSIlEpB65t7PdskwZO6O2kTahjKDh0zKmL8e+Nc9y+t6W7ZV57Q6FmsROKBI9oOSRMAMHjIpE9Q08NXA32wl0+jy+4WURGAdnkf2ndJ/r9OBTDuK5PzwcrJMokcZgR+IMd5KP3K77qDZLnbHp/8i+SzwgiLZbSy0LJPsTc6Qzvi+d9yRhfPkEbutKpE8GkK4MM5Cy4rk5XqpyeCxtiWSrk5lEoXy78YYH+7itmu+olIWs9vtsqpE8kSX9EmRfD/ty8nrFUmZUBsodyf/ZVfvTObF7I00QTvaaf8XZwBPdPFNyftFcguwBs85ZDIpBZq/Dvia1lWLrtnpesytXIsXOQDeA54a8iwVyY6ytUsdJTJGMfr+nIkndsirbC9mr3ExW4VIQgrYOaZI9qOzrE0nk045m/xC4Bs7monnIRezVc27x4E3Yfzp6BTJ2Xrp0gweiqRIw/fFGK8HZjriTZqOrk72dm1rX5GcnXXAhvy1WziiN5nuIn5rXt2Pdd5oLWZXkwLstNN62NdFA5CGYmgbSamubCORxnP77hjjDR3yJu8gFUVXJOuZe48rkv3oqIdoovtE9CaTSG4Dvq0D3mT525uAW/A8soYF2AA4BxxpvaZIdphHutZRIh2ZzP5eTrTRBW9yU17YGtna/3EFcBQ4pEh2m+I5WnZHZHZvcjvwt7twNolBO7WJ5MGcjm7QpXSIimTppSYd3bUtkXR1KvJ+vnvM3mRZzD5kV1TFwS7Ou4pkQ+mYu/NDkRR5/3xRIl2/dhzepLmVq557n+7qoJdLO+o+UuFZCy2LzKJT+fkf5CsYK+1Nlr91P+ZWrmU8lTqmncq0o0jOTakhaWSryPuZypPYFwNfPgZvsi2SV7mYrYa3gJOKZD9WyI/YFCKXpUSTfvsYJzUXs3XNuyeAV7v4BhVJLsngEWiCAVydisw9b0Tgv4gx7lrhepPmVq5TJB8LIbwbY5zqWqFvRfJS1gF3KZIil6XcTbwG+NaVspehxazp6OriqS6vCKUxtHtpatOJyJVt5htjjDeGEKZXMIDnLmCzXVAFRYOOKpL9MPitwGrM4CEyn7ljBngA+PoVmk/aEei36Un2nhJ0dZbmjmTs4kCXhp1d7SiRjk5yAN+SvcjlDqIJQ3bqYraO8fMccEqR7Edn7bQpRBY8f3wY2JEv+a/EnOJitq5591QI4WxJFKFIdq2XmmCAqzAYQGShnt00cC3wt1bAdoqnut2mr4r9XdYjPcnGqDeQzlcUSZGF2883xRjXLlcATysd3VWkeq/aaT1j55NdfpOKZNNR9+QVsRk8RBY2h0RS0NuHlnFeaedWttBy/2mnozvQek2R7DBlC8cMHiILowTQfNMyTnZFELcBN7iYrYbXSIE7imQP2GYTiCxpHvm6GOMtrQv/yyGSpqOrx5MEOA683IfBPemr4LYnKSILF7AZUlWOv7xMc4s1JOsUycMhhItdK7SsSJZeaoIBrqfJ4OEWjsjiJ72vHfr3aFQ4eadTLmar43DX591J9yTb6eisTSeydFv6yhjjzaPccm39nltJUejOXfWMl4Ndf6OKZOIhUm06M3iILH4uiaSUcV824vmlHYF+m01dxa7DADgPfHY5dh4UydGzuesdJdIDyrnhqLdc27mVp1zMViGSAM/S0ULLiuT7O8tzDpHRidmXxhivXYYo10dczFY17x7rcjq6iRfJVjq6KZoCrq5ORZYmkpG0M/PBEc4xxUPdZRNXxb4+6JDbremMY6MiKTISkZwhbYl+zQgXszHGuBbTRtYqkp1mMOEGTRbIdY5XkZHa1V+KMa4aQS5X09HVR9GdI4pkP4x5R175Tmt8IiOzq12kSNelilr52S3AdZiOru+U/nuHjqejUyQbHrUJREYqkjOk/KqPjtDzKxHopqPrv0gCHAKOKpLdZmbI+ERktBPhXxnhJLjDZq1qbOwLIVzocjq6iRbJoWCATSNc7YpIY0tfFGO8eolXQUoE+oPaaVXs70t/DibciO8E7tL4RJbFvh6gqa6zYPtq3Z+7Ba9p1TY29vXlDU+6SG4A1uLlZJFR29cMcDVNAoDFiFuZnzZnoZR+U9LRXSCdSdKHuXfSA3e25mfTXImMfkIE+IIRTIbbMR1dTbxKSkmnSPaA3Y5XkWXzJiGdS65a4rnk1r5MqDKvhdNLwGt9edMTJ5L5nGM6xjigKeDq6lRkeURyG4vPaBWHRFLqEMlPlzm465Gtk+5JrsNCyyLLKZIzpAQAjyzUzlq5lddgOrraeLJP/TmYUOOFFLRzq+NVZNk9h4eWYKd30RRaViT7TdGbg31805MokluAVRgMILLclOodM4uw063ATZiOroYFUwDOAMeHFlGKZEfZ2aeOEunzgjQnFYiLCN7ZsQiBle7uKjxHT3K2TrJIxiHjE5HlFcn7WXyycyPQ65p3j4UQzne90PLEiuRQMMD2RRqtiMxfJEvwzrzTyrUi0APmVq6NZ/umPYMJNFryqtbadCIr50EsZudmLQbt1Db3frpvb3xSRfJ+UikfgwFEVoZtQ6I538WsuZXrWCgNgIvAHkWyH5R7VwYDiKwMm/Ll8flk3mlHtl7jYrYaXgVO9G3unVSRNGhHZGXnmHuAG+f5M0UQH3IxW40nSRbI1/o6gCeFYmzbHLciK8qtwG1DInglOzWytS6RPBBCuNiXdHQTJ5KtQsvXYDCAyEoR8iR5HSkW4LJ214pAX02Ts1U7rYN9fezPwYQZK6SoViNbRVaO4hnuWICd3gms106rmnuP9PHNT6JIbgOuxWAAkZVm5wLs9D6aQsvaaX8pka1v00S29irL2SQG7jwytLoVkZXhjgXY3laaZATSb5GEFLRzTJHsR2dZm05kZfmcdxhjXDPPHK7mVq5r3j3St3R0EyWSrWCAVTSRrW7hiKysSN7Kla+BzAyJpNTBwb5qzmDCjPR2jGwVGRc358es9teKQL8OC6LXNvc+09cPMGkieR9NoWWNT2RluYYUtTqX/bULot+nnfaeErQT6Wlk6ySK5O78macdvyIran+luPkt87DTzcDVGIFeC2/TVP/o3RnzpIhk6ZhdjleRsdrgrfP43lLGzsjWOvr8KPCCItltirE94rgVGSub5jGpGoFel0g+mSNbB32LbJ0IkWwFA1xPSrIMbuGIjItbLmOnMzHGAeZsrY1n+jzvToInWTrmLqxNJzJuSv7WmcvY6ZYJmp9qpvTfoRo+xCSI5CZSkmWDAUTGZ4frY4yrLpNQYCPNNRHpL2WePU9zR7KXiSEmaaW2dY4VrIisHKvzYy4R3ZW/nnYx23uRBHgROKVI9oMHHbciY2ctaUdnLrbbRFWJ5AvAGwB9DNqpXiTzdk4JBjDNlcj4KF7hDcxe3WNGkaySPXlrvbdaU7snWZLp3kmTs9VgAJHxsWbYk2xFoF9Lc0XErdY6+FTf+7N6kczPG7A2nUgXWAVcNYed3kcK3NFO+89Uft5f1kKKZLfZnD+rQTsi41uwllyeNw0JYTto52qaFHbST4ogvgac7PuHmRSR3Nb31YxIRZPnXOWytmunVfXzs6ToVj3JHnTWNsetSGe4ag47NQK9rnn3UAjhQh8LLU+ESLbSXF2FhZZFujR5rpnFTldhDcnaOFqDztTsSRZDuxNr04l02ZMEWIe5lWube/fU8GEmQSR3ks5ATEcn0g1Wz2Kn67NQSv93CwbABeCJoR0ERbKjmI5OpFvcMItIbiNdDzGytf8iCSnTTm8LLU+aSBq0I9JdT7LwUA0Tqnyu/04CZ2r4QDWL5MyQJyki3Z1UXczWxf6cRWmqz5Gt1YrkUKFl01yJdIuSjaVEtq6mqTOpndbB3lo+SK2eZDG0e7DQskhX5512oWUj0Ouaew/VNlhr7agtwDUYDCDSZZF8gFRo2Qj0flMiW8/TpKOLtQzWWnmklo4SqVAkaYkkGIFeg0hCSiJwUJHsR2ftctyKdI4wx2JW6ph394cQ3o0xDvoetFOlSLbSXE1h0I5Il0VyOhfjfdgmqYqDNc27NW+33k6qI6lIinRRKUOYBq7HoJ3aFj97avpQNYpk+UwbgVsdtyKdZgNwhyLZe0rQzkWayNYqYkFq9iS30RRa1vhEumunV2mn1dAutKxIdpzdNXWUSEVMz2KnRrb235MEOJWFshpqFMmZGGPAiDmRrk+oYA3J2vr0U7nQ8lQNka3ViWSrAvZaTHMl0lXOZntdA2zXTqvi6do+UG2eZDG0u0nRrRqfSPc4l5/vcTFbnZYcVST7IZKbgOswzZVIF3k3P28AblIke0+ZZ88CR1qvKZIdpmzhGAwg0j3eaYmkdlqHSAI8nx+KZA/Y4bgV6RxhSCR31DahTrhIPhtCONuKDVEkO2eBKYMHNGHlbuHUZYRSB+eG7FTq4FiNulLNh8nXPogx3kVTVUCRrMsDkTr68XR+3mj/VsWna/xQgwoNcCNNZKv0n/PAmzZDFbsBgZS27HSM8RYsiF5Lv06REkTsqfED1iiSm/LXprnqNyWY47PAE0OvSX+ZJkVB7sZCyzXxOnC8JZyKZIfZVmNHTegKFeAvgLdtjmq4mPtzpwufquz0OPCKItmPzrLQcl07A4eBO22OauzzzexJ3m+TVNWv+0MI79VSaLk6kWwVWl4NbBmaZKWfhjcALgB7gattkmp4I4RwHthqU1TFgVrn3Vo8ydIx6zFirqbV6SngWWC1TVINb8cYr8N0dLVQ+u9IrR+wNpHcDtyAwQC1iOQB4CVglU1STZ++Cqyjybajnfa7Tweke69PDvWzItlRHszPBgPUwTOkKyBTNkU1HADuyItZRbKOhc8p4IQi2Q8856hrZ+CpEIJXeeriLeCD+etpm6MKkTwWQni7tnR0tYlkKbS8xXFbzbicAQ7kYCyv89TD68CjNkNV7K/U6arjQ7VWLzfiOUdNq9PTpNp0a+zPquaal7XT6tg7CQO3zxRDu4vmPp3G13+RPEkK8jCytQ7aBdGNbK1LP45Mwoeswfi2ku7TeYZVh0ieyDsEU/ZnNZzPImlyiDrsNOQ+fXbIdhXJjrK75o6aQA62FkH2aR0LnwuktJHX6klW06dHqDiytRaRLB3zAcdtFZSJ82irfxXJOvr0WuCLbI6qRHJPCOF8jenoqhDJVjq6NXjOUYvhDfJzCQaYwXuvtbAKuMlmqIq9tc+7ffckS8fcgRFzNXGapuzODN6nq9EDkTrm3oO1f9BaRHITqTad1DGBngRebImkE2t9k6v0205LAYL9tS9+agnc2ZyNb1ojrEIk94UQplsi6XarSPfs9EUqj2ytSSR3O26rYi+kM2dFUqSzvAi8VvuH7LtIlnR0imQdlF2AA+0+xjNJkS56ko+FEGLNka29FsmhdHTbKvOMJ9XwBsB7XJrBYzq/JiLd4smhxa0i2VGv427gNsdrNavT54BjQ57keZtHpHO6cWCSPmyfRXIDcA0WWq5FJI+GEM7kbfSQS2W9NPQ9IjI+Ow3AGSYgaKfvIlnY3vI4pP88M8vYfNtmEenUYvY5UrFlRbIH7HDcVsWeWXYL3rVZRDolkkdzOrpQc9BOr0UyhDCdt+S2Om6rYCob4P5Z/k+RFOkWJypytOoTySyOkPJAPjDkdUh/V6dznXOctYlEuuGf5OfHJ+UDD3r+vreRii0rknWI5As06ejaInnKJhLphJ0OgIstkaw+mK7vrvJm0jadhZbrEMn9c5TdecWFkEhn7PRFKq8hWZNIbpuUjpoQnpljXL5p04h0RiRPAG9Myofuq0iW6x67HLdVUDzEp4eMsTyf5tJakyIyPg7kOr5TtUe29lIkS8hxjPEqmshWt+H6vTodkCJYD8yxM/A6RriKdIV9k/Rh++hJttPR3aNIVsMrzJ3B4yxwziYS6cTce0SR7EdHbSElNzcdXb8pW+fHef85RxHLN0nXQ2YTUBFZfsqOzzng8CTZYp8Ddz44NMlKvzmczzlmK7tzriWSIjIekYRUfOCgItmPztrsuK2KvUM7BW3eA97SkxQZ+7x7OITwbu01JHsrkjlopxRafsBxW9UYfF86uhygVXJDvmZTiYydw5dZzCqSHeJGUomsieqsSlenAXiHuc85yhhVJEXGx/A1rYlbxfeto9YDdyqSVYgkwPOk0juziWThFZtLZGx2OiDFfxyZtA/fV5F8ALgaI1trEclDIYS3rlB257DNJTJW3qJJRzcxAZN9Fcndk9ZRlXN4HuPxNXcORMa6mD3BBO7o9E0kp/Pzo47bqtg/DwM9mfvf1HQi4xHJJ3IBgqlJiWztlUi20tGtISUS0KuoY/xF4NA8vvcV4G2bTGRs7JnUSaovtNPRrVckq1idBlI2nf1DK9bZVrGngZcv830isrxz75FJ/PB9FMkNwE2KZBUiCemc48UriV8I4S2a4suKpMjK2emAdE3rwCTaXx/vSW7J4mjQTh0ieSCEcGGuDB55i72M02M2m8hY7HQ+17QUyY6wU2+iKp6ex65A+b+jNpfIWETyOeDNK1zTUiTHTPEcdztuq6AI30LuPz5ns4mMhUNZHAeT9sF78YFbka23ANt67AVLszodABdZWEWBY62fdSdBZOX41KR+8L4ITfE67iFFt0odvEY665iPqEKKrjuDAVsiK7WYncrP+xewmFUkxyiSm4BVmI6u78y0PMOXAUIIM/MQyZeAZyfVWEXGxBs06ej0JDvO9qFJVvrNoRDCdCt6dfYVUlMy6wLNXS1FUmT5PUmyQL6kJ9mPztruuK2K+US2Do/Vp202kRWddyeu0HLvRLJVaHmz47aqcbd3ET97YAHCKiJL59Ak21znRTKLI8AtpBJZffKAZfbVaSm0fHRoxTqfVe1B0na7Ea4iy+yf5Of9ruj70VGbgdsct1WIJKSo1oWkmSvfcxR4wWYUWXY7HQDvAo8twE4VyTGK5E5SZOsMbrXVIJLPhhDOQArMueIgaIJ3TtNs0xrAJbK8dvocqUydItkDtkxyR1XI0wAxxqlFjNfHbT6RFRHJEyGEtyYxHV2fRNLI1jrZP7RTsBA+s4SfFZGF2+nExoF0+oPn1ctMjPFqLLRcy+q0ZPB4ahE7A+V7nyEF/hi8I7IyIjmxdH11UATxLlIdSUWyDl6hiWxdyLli+3LzRJbtEVlhbThoQ/RDJLcA12M6uho8SUiRra8seDDk2pIhhLcX6YmKyPzsNADnMQ1kb/aZdy/C65DuiuThEMJ7iwwGKIuk/2RziiyvnWIayM6LZOmYz3PcVsWhJYy/MiY+BUxjYgmR5Zp3909yOrrOi2QraGcAbHTcVkHxAp8agQHvI51LBncYRJaFpUSgK5IryM3AfT16vzK3uA2y93dgSPDmr7JNUoHXgScX+3tE5IqL2f02RbdFp11o+Q67qgqRhBS0c3yJ4lbG7cdtVpFlWcxepIlsnehFaB9E8n5gDaajq0UkjwFnWonrl/K7/mM25imbV2SkvEqTjk5PsuM87GqmKg6EEGaApQQDtJMKlOg7zyVFRreYfQk47dzbbZEsHbPDcVsVSz7naN2XPAf8hYYsMvJ597MhhIuTHtnaWZEcSkdX7ki61VrHWDs0ot9XxsOfOj5ERs4T2lW3PcnSMbeTUtLZWf1fnQbgbdIF5VF4fuXn/wQ4g3lcRUapCQdtin6I5AbgJrupCpGEVCz5xChEMu80hBDCceCT+WXPJUVGs5g9PqLFrCK5zGzNnTatJ1mFSB4B3hlhbboyfv/QJhYZmZ0+jwUEeiOSOx23VbE3i+NgxEb9J3gVRGRU9nQ4hHB2kgst90Eky7bZg47bqnhqmYz6KWDP0NgRkcVxsidO1GSKZFm9xBhvwELLtaxOS6Hlo6P8xXmcTIUQLgC/PSScIrJAk8rPn7Ipuu1Jlo7aSkpJp0jWwRs0QTvL4e39PlYFEVmqHkyTknRID0RyA7AK09HV4ElCCgR4aRl+fxHcx4C9WBVEZCl2+toyL2YVyRGybajzpN/Gtz+EcH7UGTxaW67ngV93zIgsyU5P0qSjk46KZBwSSamDZ4Z2CpZjzPw74DzNGaiILMyGDoQQ3jMdXUdFspWOLgCbl3FSlZWj9N/eZfsDzZh5hpRYIOJWkchi2Ou8231PEuBWYJPdU8XqdABcYAmFluc7lnN1kV/LBq6Riyx8MXvMpui2SJaO2khTaNnJrt8iCSlg59Qyi2T5vR8FXsFcriILXcyeb3mS2k7HRfLh/N6MbK1DJE8Ary/rwElbroMQwvPA7+WX3XIVmb+dnqRJbK5IdlQkC9vtqKo40RKx5ezTsqD6pdbqWETmJ5JHQwjnTEfXbZEsK/+tdk1VPD4kYss9fv6YVA/PO5Mi8+dQx52nyRbJVjq6azEdXW3ja+9K/LHWncl3gZ8fWiWLyBymk5/32BTd9iRLR60H7lUke0+pTXeO0RVanu/fhZRY4DW8MykyHx2ILU9SOi6Sm4HrWpOs9FckIQUDPL9SItk6+zxJug4CbrmKXMlOzzGiguiK5PKL5C4ntqqM72gI4e0VDgYoY+kjwHt4HUTkSnZ6GHhBkey2SBZR/KDdUhX7V3qshRCmcwaeTwMfwwAekSuJ5FMhhHdMR9dRkWylo5uiiWx1q7UODo5rbOcMPD/leBK5Iqaj64EnCbAOuNPOqmJ1WgJm9o7pPZR8rr+bPcpSK09EGso8e9Sm6LZIlo66B7jdbqmG11vGt6JbOHnLaBBCuAD8tAsvkVkXswPgXZpjEbdaOy6Sm7HQci3GB3AceHGMxle8yV8l3QHzbFLk/Xb6MisYga5ILg3T0dVlfPtzEM1YggFa3uQ54P/IIunYErnUTl8g3SnGoJ3uimTpmN12SVV0IRigeJP/lrT1O9CbFLnUTsv9YpuigyLZimy9uuVJutXab0r/HRj7G2m8ydeBH3NsibyPx5x3u+1Jlo65m6bQsp3VX0owwEWaAq7j3sIp3uQvAvv0JkUuqZKz1+boh0huANbimVEtPE8K3Bm7SLa8ybPAv7JrRD43975JSh3ZhcWsInkFSuUPI1v7TfHQjocQTrdEauzvK3uTvwZ8Rm9S9CQhC+RzimQ/RPJBu6MqngHIWZTGv2RuvMl3gR9QIEWRBOBgCOG8hZa7LZJlstphd1TFU117Q63rKL9NysRjFh6ZdI500GFSJD+3lGkKLd9Ek7PVzqpjTO3v6PsrW/k/QCoP5N1JmUSKHeyzKbrtSbYz7dxhd/SeUgP0DB0NBsje5FQI4TPA/4lnkzKZdjoglZF7vIt2qki+XyS3A2swaKcG44OUwaPLteliDuL5EeCUQikTaqcvYmRr50Wy8IAdVZXxHcq16ToZDJBLaA1CCC8A/8KFmUwoJ0hFCKTDIlkm0M12RVXs6dgibDZKGq6fJxVmNohHJm0xeyDHhFhouYsiOVRouYikK/p+U/qv8xk8yqSQS2n9D8A7GMQjk8UB593ue5IANwH32VnVjKdp4PDQirWrQjmTg3geA34SzyZlshazB22Kbotk+dubaCJbFcn+UgTxVbqTs3U+lG3Xf0m62zmlUErldloKLZ/okZ1OtCe524mpKpE8CZzuzZK62XY9C/xjUmL26MQhldvp8ZYn6VjvuEh+0I6qyviOhhAu9ikYoLXt+ofAT7hokwmw0/0hhHMG7XRbJMskZGRrXZRMO33bOi/brj9IumCtUErNHOqpnU6GSLbS0V0H3G9nVUHpvyd7+eabbde3gL9HOrNpr7xFalzMSkc9yTKh3gfco0j2nnYwQC8iW+cQyrLt+glSblejXaU2O50iRaAfsDn6IZKbgGtpcn5Kf40PUiq6vqe5KtuuP0aqFFImFZFaeB04Wsa7zdFNkSw8aEdVJZIHQwhn+lybrrXtOg18F6kgreeTUpOdvkiPItAnVSRLZz1sF1TFoY4svpYqlGXb9STw35GuhfTZOxZpj9/HQgjvGtnaUZFspaNbBewq85JdUQXVnHO0Smr9Hini1fNJqYWnnHe77UmWjrkVM+3UNo4OV/a5Sm7hHwY+iueTop0qkivIPcA6u6D3tAst72u9VoM3GYEYQrgIfCepuonnk9JnO30HOFKTndbsSW4GVmGh5RqMD+BZul1oebFCWc4nXwG+LS8G3HqVvtrpC6RgNEWyB57kNjuqKuM7XGswQOt88rOkQJ7o2JWe2ukJ4M0Yo45Jh0WydNYOm78q9gztFFRFSyh/Ffgf9Salp5zMi1gjW7sokq3I1tXA9pon1Qmi9N++CfisZev1R4CfwUAe6R8ftwm67UmWCXUD8IAi2XtKOrppmmCAelcDaeVdMvL8A+A3slBedChIx+20BJw9bXP0RyTXYjq6WngDONUyyNqFkhzx+t8AnyYFoOlRSh/s9NlJsNM+i2RhS372TKf/K1SAY8BLk2J8+chgEEJ4HfgGUuUTt16l63Z6AnhZkeyHSO606asyvgMhhPcmKc1V62rIc1koDymU0nE7PRRCuGA6um6LZPEcd9v0VTGRaa5aEa9HgW8mVUAx2YB0lf2TaKe9EclWoeUbsdBybeNn76Q2QEsonwS+CXgVr4dINzluE3TbkyyCuBFYr0j2nhJ0dZ4JT3OVhXJVCOHTpK3X0wqldMhOp4ALwBOTbKd9EslHMB1dLcYHKcXVqUk3vhDCxexR/lkWyuJRekYpXbDTUzSFlhXJjopkYbMdVZXxnQghvNnnQssj9iinQggfA/4aKdzeYB7pgp0eDyGcyePUubejIhmHRFLqYM8YF1xdFspPAF9P2opWKGXcHALIiTCkayLZSkc3hUE7tbHX/pxVKFeFEJ4AvgZ4RqGUjixmtdMOe5IAt5ECd+ysflOCAaAJK3cL51KhLGeUh4CvBj6DKexkfHP8AZui2yLZjmy91WavhlcxGOBKHmVJOPB1wG/TpLCzvWQlFrMlAv2kdtoPkdxBE/GnJ9lv4yMb3osa3xWFchBCeJl0j/Jns0cZbTNZITs9okh2XyQLj9rkdRlf3lY0zdXlhbLken03hPB3gP8l217Au5Sy/Hb6TAjhnHbabZEsE8E2m7wqDg7tFMjlhTLkier7SRVEzuFdSll+TEfXZZFspaNbC9xrZ9Ux5w8Zn8xPKGMyiTgVQvgI8FdJFVSMfJXltNNDNkW3PcnSUXcCdyuSvaddaHlP6zWZp1C2roj8MfAVwJ/QJEa3LWWUdnrRxWx/RHIzFlquxfgAnsdggKWIZbkicowU+fpvaM4p9SplVLzcslPPvzsqkoVtdlRVInk0hPBa8Y5slkUJZYl8PRdC+C7SOeWbuP0qo7PTl0hXtaQHIvmQzV0V+wByFiVZvFC2A3o+Anw58BjN9quLSlmKSD7diq52Mds1kcxBO9MxxjUtkXSrtQ7M4DE6oYwlbWMI4THSOeVPZ/s0+lWWwuPOu/3wJNcBm+ysqsbMQZti5GJZMvScCSH8feBbSCWODOqRxdrpPpui2yJZBPEe4Cabu/eUoKu3MR3dcgpl2X79ReBLSensDOqRhdrpOQyu641IPtBaDetJ9tv4yIZ3XONbNqFsb78eJZXc+u+Bt2iCemx3uZKdPkeqaaqddlgkCzvsqKqM73AI4byFllfEqxzkr38ie5V/lIVSr1LmY6dntdNui2TpGNPR1cX+FV5kTbJQzkCKIs71Kf9z4HuA0xgBK5fnqHbaYZFsFVpeBWwvNm+T93vOzs9P2xQrKpSxdadyOoTwk8CHgV/n0ghYvQVp2+njNkW3PcnSURswsrUG2unojgztFMgKeZU5qGcqhLA/hPCNwN8g5eZ0C1badnoR+Kx22g+R3ALcgOnoauF1jJjrhFeZd2t+BfgQ8GPAOzS1Kt2CnVyRhFTn1aCdjotkoXiRGm0dxneKlA9SxuxV5uo6UyGE0yGEfwZ8CfDRvBgtXr92N5l2ejIvaKUHIrndZq7K+J4JIVwwzVVnxHK6tQX7WAjhG4BvBD6dvUrPKyeTg6aj675IlhXsLpu5KkoGD7fOuyOUw1uwv066LvI9pPPj9nmlE+ZkcEA77bBItgot30BKJGBnVTAX5+c9NkVnxbK9BXs+R8F+IfA/A68olhNlpxZa7rgn2Y5sXa9I9p4SMfdOa4XqJNtdsWxvwZ4OIfwg8AXAj9OU4lIs67XT88Bh7bQfIrkLWI3p6GowPoAXSKmuNL7uC2UcEsvjIYR/kj3LnwTOKJbV2unJlidpv3ZUJAuP2FFVGd+xEMJbZRK2WXolloPW/crvAb4I+CmazD1FLI2G7b+dHgwhnDMdXbdFsnTMBpu4Ko6ChZZ7KpYzs4jld2fP8n+lKck1wFR3fefwCjlBiuSi1LFJRzeFQTu18aRNUJ1YHgkh/FPg84F/TNqmK6nuIm7F9hFrSPbAkwS4DbhPkaxqnOy3KaoVyxdCCP8aeJRU7Plj2W7diu0HkSbb0gGbo9siWQTxviyU0n/jC6RAD3O21iuWJcDnzRDCL4YQvoxUceTf0kTE6l12nzM01T9c1HRUJMvv3EFzvqEn2W+RhFRk+QVFslqxvCQaNr/2ByGEv529yx8C9upddt5OT5LuxEqHRbJ01i4n1KqM70gI4V3TXE2GWEIK0Mr9fSiE8H2ku5b/FfBbwNlZvEsFc/x2+nguiK6ddlgki6F8ns1bFaa5mjzBnC75P/NW7NshhN8IIXw9KSr2+0i1RQOXRsa6HTs+9mqnHRbJVjq6a4F77ayqMM3V5IrlJeeW2c73hhB+iBQV+1eAnwGO5TmlbMfO6GGuXDfl52M2xWhZtQwdFYG7gbsUyd5TIuYuYmSrs3DavitbsYP0UngX+EPgD2OMN2fB/FrgK2hSUpaxVOITgvPCyO10AFzAdHS9EEmA+4HrsdByLbxOEzGn8QkhhJkslqV2JSGE14FfAX4lxnh7FspvIJ1l3pcXXIVpBXOkIhmAl7DQcm9EsgTtzAwZhvSL0n9HgFc1PrmCd1kEM4YQXgZ+CfilGOOtwBcDX0e6VrJhFsEs84dZYhYnkmSBfK3VL9JBkSwd86BNWxV7y8Xz4kGILEAwXwV+E/jNGONNpJzOXw58JfAB4OqhX9UWTT3N+XOkVWhZO+2aSObD/Ol8x2qnTVsVFlqWUQgmIYQ3gD/Jj++PMe4mRcp+CfBhUirLKUVzUXxGO+22J9kO2tmaX3PrpN+U/jtoU8gyCOZ0CGEPqZD3/xVjXEu6OvaXgA8CDwEbZxHNGZpzuEkXzdiy072Otu6LJKSrHze5oqnC+AKpgKvp6GS5BLM8YgjhLCln7Mfy/99Eim/4MPCfAdtI55lXzTJWZybY2wzAOVK2He20wyJZuJ/mjpSeZP9F8qTGJ8somJ8bU20vE5jJW7N/nh9kT3NT9jI/RIqafYAUST91GeGsWTyLnZ7CtJG9EcktdlQ1xgcpGOAtC7jKSnqZs4hm8TSfzo//O8a4mrRz9UD2OD8A7CZt0d7C7JH1s4knPRZQ7bRHIlk6ZpvNWhUlHd2gPYGJjEk0PydmIYT3SPd3j5ISGpQkB/fkeej+vGjfTCq4cC9wDXNfS7ucgDLL19qpIjlPdWwKLa9ueZKeR9bBMzaBdEg041yimb3NGS49Iijfey0pocH67G3eT9q6vRO4PT9fxZXvdQ8LaVcE9ZDzbvc9SUj1IzfYWVVQCrha5Vx6IZpzCCek881zpNSK+4E/an3/ALgxi+d9pMj8daRrbLdmAb0FWEu6zzlgYQlSYusxasrvnAE+2/paOiiSxcXflQeU6ej6Tem/12jSXGl80kvhvIJ4zpDSLr5Ouoryu0M/dx1wQ+txL2k798bsid6RRfM6UlT/jaQt3euzZ7oSZ50vtzxJzyM77kluoynGajq6/ovkKeBFm0MqF0+4NPo1krduQwhvA2/TRI5+ek6jSVu612aPc10WzeuyYF6fv74qP9ZkMV1D2upd1Xofg/wIs3ijF4HngTeBd/Li9Ymc1ch0dD0Qya02aTUiCXA8hHDBiDmpXDzn9MCGRJQhIaUlqDFv6Z7Lrz9n6yqSbcpW3A6btCqeys9GzIkierlVZSOmw4K6kEXpvN/WLO9T++yqSLYKLd9Auq+0kMEhHZ0b8rORrSILE9PFiJ50mFFkxCkT6gZS3lZFst+UXJDv0RRa1uhFRJFcokhuIx1IzyiSvRdJSIEKxxVJEVEkR8MHnVCrEskTwBmbQ0QUydFMqltszqo4lM+ap4xsFRFFcjHq2KSjmyJdsgW3WmvBTDsiokiO6PfcSkrppEjWMyaesilExAlxND+/gZS3VfpNybRzllRZobwmIqJILoHNpDR0Rrb2XyQhZQs5pUiKiCI5GnY7oVYlkodCCO+Yjk5EFMmlUdLRPWxTVsXBES+iREQmSyRb6eiuA7bnl91qrYP9NoGIyNI8hSKId9EE7SiS/aaUNztqU4iIjEYkN5JqpVloud+Us8fXgMP5awsti4giuUR2OaFWJZInSUVdRUQUyRGKpNQhkgdCCBdjjAMjW0VEkVwkrSKfD5aXbM4qeMr+FBFZgkiWKtwxxruA+23GKiiiuNemEBFZmidZfm4LcPtSvVIZO6XQ8nngSOs1ERFFcgmUpOYG7fRfJAFeIaWkUyRFREYgkpudUKviCHCmbKeLiCiSS/M8dtiEVXmSh0IIM4CRrSIiixHJoULLW/LLeh51sMcmEBFZmifZTke3UZGsahwY2SoiMiKR3ALcZBP2npJO8C0stCwismSRLDySJ9dpPcneiySkIssvKpIiIqMRyS02X1UieSKEcM5CyyIiSxPJcifSTDt18cwIFk4iIpMrkq1Cy2tbIulWa78p/fe0TSEisjRPskyo9wD3KpK9p6Sjmwb22xwiIqMRyZ3A1aStV0Wy/7yEOVtFRJYskoXdTqhVUM6XjwOvAuSMOyIisgiRLKL4qE1XFYfzWbNBOyIiixHJVjq6q4AN+WW3Wutgn/0pIrI0T7JMoLcD651Uq+p/g3ZEREYkkpuAW2y63lPS0Z2jydnqGbOIyCJFsrAV09HVIpKQ0tE9r0iKiIxGJHfZbFWJ5JEQwlnT0YmILE0kZ3LF+odstqrYt4QFk4iIItnyMm5reZJOqnVw0CYQEVmaJ9lOR7fOZquq74/YFCIioxHJDcAqTEfXd0pk67vAC63XRERkESJZ2OaEWo1IAjwHnLBPRURGI5LbbbKqRPJoCOEtI1tFRJYgkiGE6ZzX8wGbrCostCwishSRzNc+IGXZecBJtQpKn+6xKUREluZJlu/ZCdwxNMlKf0VyBq9/iIgsWSQLG/P3W2+w35TI1teBY63XRERkiFUL+N678mTqhNodsZvP66H1HEk5d6dI55HPg4WWRURGIZIDmm26wRwTsSyvKMaWJzjXLkC4ggdZ+vzf5PqgUyGEaZtXRGRxIlk8k0+RLp9fdYXvi/P0eBYywS/1e8f5O5fiIcZZFint/3sHuNjyEKfza28D7wFrSfU/1+afvQg8C/wM8Mv56ocCKSIyClGIMX478N+SzidvBNZkoa0p2jUu8PVR98PlPMFDwF8AT5DSyZ3OC5cikO+R6kO+k/99LSmV4N15cfMKsDeE8LxDX0RkGTynGOO1edK9OXsoa4HrgGuyaF6bv15NOvtalSfoa4Cr8/eU/5tqfc/qodcHrf8rz6ta/25/X/GyBkOP0Ho9DD2Y5d9doYjdaVJGnM8AHwMeCyG8sORVQIwDzyFFREbvSS7b5JrvY84mbm3BnBoSycHQ9wyGvndqlv+fav2Nqcv8zKpZfn6272+/n9KeM1x6hjhoedszpG3Pi1kM248LwHngLeA14GXglRDCxVnaab5eb3sREIFodh0RkeXzJGfzvMIcE/TlJu/0g07Y81qc5Daesb1ERDosksvoRY7rvY/q94wyQOmSICiFUURERERERERERERERERERERERERERERERERERERERBbC/w+oCy5cDTEtoAAAAABJRU5ErkJggg==") center/60% no-repeat,#0A0C14;font-size:0}
+.ev-core b{font-family:var(--font-display);font-weight:700;font-size:18px;display:block;line-height:1.1}
+.ev-core span{font-family:var(--font-body);font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:#5A6072}
+.ev-rail{position:relative;padding:6px 0}
+.ev-rail::before{content:"";position:absolute;left:23px;top:30px;bottom:30px;width:2px;border-radius:2px;
+  background:linear-gradient(180deg,var(--edu),var(--content),var(--space),var(--care));opacity:.55}
+.ev-row{display:flex;align-items:center;gap:15px;width:100%;text-align:left;
+  background:transparent;border:0;cursor:pointer;padding:10px 0;position:relative;z-index:1;color:var(--text);font-family:inherit}
+.ev-num{width:48px;height:48px;flex:0 0 auto;border-radius:50%;display:grid;place-items:center;
+  font-family:var(--font-body);font-weight:700;font-size:15px;color:var(--c);
+  background:var(--bg-2);border:2px solid var(--c);box-shadow:0 6px 18px rgba(0,0,0,.5);transition:transform .25s var(--ease),background .25s var(--ease),color .25s var(--ease)}
+.ev-txt b{font-family:var(--font-display);font-weight:600;font-size:19px;display:block;line-height:1.18}
+.ev-txt small{font-family:var(--font-body);font-size:10.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted)}
+.ev-row.is-active .ev-num{background:var(--c);color:#0A0C14;transform:scale(1.07)}
+.ev-row.is-active .ev-txt small{color:var(--c)}
+.ev-row.ev-base .ev-num{border-style:dashed}
+
+/* ============ DOMAIN DETAIL GRID ============ */
+.domain-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-top:14px}
+.domain-grid .card:nth-child(4),.domain-grid .card:nth-child(5){grid-column:span 1}
+.card{
+  position:relative;background:linear-gradient(180deg,var(--surface),var(--bg-2));
+  border:1px solid var(--hair);border-radius:var(--r-md);padding:26px 24px 24px;overflow:hidden;
+  transition:transform .35s var(--ease), border-color .35s var(--ease), box-shadow .35s var(--ease);
+}
+.card::before{content:"";position:absolute;left:0;right:0;top:0;height:3px;background:var(--c,var(--edu));opacity:.9}
+.card::after{content:"";position:absolute;inset:0;border-radius:inherit;opacity:0;transition:opacity .35s var(--ease);
+  box-shadow:0 0 0 1px var(--c), 0 22px 60px -22px var(--c);pointer-events:none}
+.card:hover{transform:translateY(-6px)}
+.card:hover::after{opacity:.55}
+.card .stage-tag{font-family:var(--font-body);font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--c);margin-bottom:14px;display:flex;align-items:center;gap:8px}
+.card .stage-tag b{font-weight:700}
+.card h3{font-family:var(--font-display);font-weight:600;font-size:24px;margin:0 0 8px}
+.card p{color:var(--muted);font-size:14.5px;margin:0 0 18px;min-height:44px}
+.card .brands{display:flex;flex-wrap:wrap;gap:8px;border-top:1px solid var(--hair);padding-top:16px}
+.card .brands span,.card .brands a{font-size:12.5px;color:var(--text);background:rgba(242,243,247,.05);border:1px solid var(--hair);padding:5px 11px;border-radius:8px;font-weight:500}
+.card .brands a{text-decoration:none;cursor:pointer;transition:border-color .22s var(--ease),background .22s var(--ease),color .22s var(--ease)}
+.card .brands a:hover{border-color:var(--c);background:rgba(242,243,247,.09);color:#fff}
+
+/* ============ PROOF ============ */
+.proof{background:linear-gradient(180deg,transparent,rgba(22,26,43,.4),transparent)}
+.stat-row{display:grid;grid-template-columns:repeat(4,1fr);gap:24px;margin:0 auto;max-width:960px}
+.stat{text-align:center;padding:28px 14px;border:1px solid var(--hair);border-radius:var(--r-md);
+  background:linear-gradient(180deg,var(--surface),transparent)}
+.stat .num{font-family:var(--font-display);font-weight:700;font-size:clamp(38px,5vw,58px);line-height:1;
+  background:linear-gradient(160deg,#FCEFCF,#E5A92B);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent}
+.stat .lbl{color:var(--muted);font-size:13.5px;margin-top:12px;letter-spacing:.02em}
+.proof-foot{display:flex;align-items:center;justify-content:center;gap:30px;flex-wrap:wrap;margin-top:48px;
+  color:var(--muted);font-size:14px}
+.social{display:flex;align-items:center;gap:18px}
+.social .s{display:flex;align-items:center;gap:8px;color:var(--muted);transition:transform .25s var(--ease),opacity .25s var(--ease);opacity:.9}
+.social .s:hover{transform:translateY(-2px);opacity:1}
+.social svg{width:22px;height:22px;display:block}
+.stars{display:inline-flex;gap:3px}
+.stars svg{width:18px;height:18px;fill:var(--edu)}
+.proof-foot .sep{width:1px;height:22px;background:var(--hair-2)}
+.proof-foot b{color:var(--text);font-family:var(--font-display);font-weight:600}
+
+/* ============ CTA ============ */
+.cta-band{position:relative;text-align:center;padding:84px 32px;max-width:var(--maxw);margin:0 auto;
+  border:1px solid var(--hair);border-radius:var(--r-lg);overflow:hidden;
+  background:radial-gradient(900px 360px at 50% -30%,rgba(229,169,43,.18),transparent 70%),linear-gradient(180deg,var(--surface),var(--bg-2))}
+.cta-band h2{font-family:var(--font-display);font-weight:700;font-size:clamp(30px,4.4vw,52px);margin:0 auto;max-width:18ch;line-height:1.08;text-wrap:balance}
+.cta-band p{color:var(--muted);max-width:54ch;margin:20px auto 34px}
+
+/* ============ FOOTER ============ */
+.footer{border-top:1px solid var(--hair);margin-top:96px;padding:54px 0 60px}
+.footer .wrap{display:flex;justify-content:space-between;align-items:flex-start;gap:40px;flex-wrap:wrap}
+.footer .brand small{margin-top:4px}
+.footer .fcol h5{font-family:var(--font-body);font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:var(--faint);margin:0 0 16px;font-weight:700}
+.footer .fcol a{display:block;color:var(--muted);font-size:14px;margin-bottom:10px;transition:color .25s var(--ease)}
+.footer .fcol a:hover{color:var(--text)}
+.foot-links{display:flex;gap:64px;flex-wrap:wrap}
+.footer .legal{width:100%;border-top:1px solid var(--hair);margin-top:40px;padding-top:24px;
+  display:flex;justify-content:space-between;gap:18px;flex-wrap:wrap;color:var(--faint);font-size:13px}
+
+/* ============ REVEAL (nội dung luôn hiển thị; animation chỉ tô điểm) ============ */
+.reveal{opacity:1}
+@media (prefers-reduced-motion:no-preference){
+  .reveal.in{animation:revUp .7s var(--ease)}
+}
+@keyframes revUp{from{opacity:.5;transform:translateY(22px)}to{opacity:1;transform:none}}
+@keyframes drawJ{from{stroke-dashoffset:1}to{stroke-dashoffset:0}}
+
+/* ============ RESPONSIVE ============ */
+@media (max-width:980px){
+  .navlinks{display:none}
+  .nav-cta .btn-ghost{display:none}
+  .domain-grid{grid-template-columns:repeat(2,1fr)}
+  .stat-row{grid-template-columns:repeat(2,1fr)}
+  .section{padding:76px 0}
+  .node-label{font-size:20px}.node-sub{font-size:12px}
+}
+@media (max-width:680px){
+  .wrap{padding:0 20px}
+  .hero{padding:64px 0 40px}
+  .journey-rail{grid-template-columns:repeat(2,1fr);gap:30px 0}
+  .journey-rail::before{display:none}
+  .domain-grid{grid-template-columns:1fr}
+  .stat-row{grid-template-columns:repeat(2,1fr)}
+  .proof-foot .sep{display:none}
+  .foot-links{gap:34px}
+  .nav .wrap{height:62px}
+  .brand small{display:none}
+  .brand .mark{width:34px;height:34px;font-size:19px}
+  .nav-cta .btn-gold{padding:10px 15px;font-size:13px}
+  .nav-cta{gap:9px}
+  .lang-opt{padding:5px 9px;font-size:11.5px}
+  .eco-orbital{display:none}
+  .eco-vertical{display:block}
+  .eco-hint{display:none}
+}
+
+@media (max-width:430px){
+  .nav .wrap{gap:8px}
+  .brand span:not(.mark){display:none}
+  .nav-cta .btn-gold{padding:9px 13px;font-size:12px}
+  .lang-opt{padding:5px 8px;font-size:11px}
+}
+
+@media (prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .reveal{opacity:1;transform:none;transition:none}
+  .brand .mark{animation:none}
+  .path-journey{stroke-dasharray:none !important;stroke-dashoffset:0 !important}
+  *{animation-duration:.001ms !important;transition-duration:.001ms !important}
+}
+</style>
+</head>
+<body>
+
+<!-- ============ NAV ============ -->
+<header class="nav">
+  <div class="wrap">
+    <a class="brand" href="#top" aria-label="NhiLe Holding">
+      <span class="mark" aria-hidden="true"></span>
+      <span>NhiLe Holding<small data-en="Ecosystem" data-vi="Hệ sinh thái">Ecosystem</small></span>
+    </a>
+    <nav class="navlinks" id="navlinks">
+      <a href="#ecosystem" data-en="Ecosystem" data-vi="Hệ sinh thái">Ecosystem</a>
+      <a href="#journey" data-en="Journey" data-vi="Hành trình">Journey</a>
+      <a href="#proof" data-en="Proof" data-vi="Minh chứng">Proof</a>
+      <a href="#contact" data-en="Contact" data-vi="Liên hệ">Contact</a>
+    </nav>
+    <div class="nav-cta">
+      <div class="lang-toggle" role="group" aria-label="Language / Ngôn ngữ">
+        <button type="button" class="lang-opt is-active" data-lang="en">EN</button>
+        <button type="button" class="lang-opt" data-lang="vi">VI</button>
+      </div>
+      <a class="btn btn-gold" href="mailto:contact@nhi.sg" data-en="Partner with us" data-vi="Đồng hành cùng chúng tôi">Partner with us</a>
+    </div>
+  </div>
+</header>
+
+<main id="top">
+
+<!-- ============ HERO ============ -->
+<section class="hero" id="hero">
+  <div class="hero-glow" aria-hidden="true"></div>
+  <div class="wrap">
+    <span class="eyebrow reveal" data-en="The NhiLe Holding ecosystem" data-vi="Hệ sinh thái NhiLe Holding">The NhiLe Holding ecosystem</span>
+    <h1 class="reveal d1" data-html data-en='We build to <span class="ital">give back</span>.' data-vi='Kiến tạo để <span class="ital">phụng sự</span>.'>We build to <span class="ital">give back</span>.</h1>
+    <p class="lead reveal d2" data-en="What began as an inspirational YouTube channel has grown into an ecosystem spanning education, content, technology and real-world spaces — so that everyone can learn, connect and become fully themselves." data-vi="Bắt đầu từ một kênh YouTube truyền cảm hứng, nay là một hệ sinh thái gồm giáo dục, nội dung, công nghệ và những không gian thật — để mỗi người được học, được kết nối và được là chính mình.">What began as an inspirational YouTube channel has grown into an ecosystem spanning education, content, technology and real-world spaces — so that everyone can learn, connect and become fully themselves.</p>
+    <div class="hero-cta reveal d3">
+      <a class="btn btn-gold" href="#ecosystem" data-en="See the full ecosystem" data-vi="Xem toàn cảnh hệ sinh thái">See the full ecosystem</a>
+      <a class="btn btn-ghost" href="#proof" data-en="Read the community story" data-vi="Đọc câu chuyện cộng đồng">Read the community story</a>
+    </div>
+
+    <div class="journey reveal d3" id="journey">
+      <div class="journey-rail">
+        <div class="jstep"><div class="dot">01</div><h4 data-en="Understand yourself" data-vi="Hiểu mình">Understand yourself</h4><span data-en="Education" data-vi="Giáo dục">Education</span></div>
+        <div class="jstep"><div class="dot">02</div><h4 data-en="Grow" data-vi="Phát triển">Grow</h4><span data-en="Content" data-vi="Nội dung">Content</span></div>
+        <div class="jstep"><div class="dot">03</div><h4 data-en="Connect" data-vi="Kết nối">Connect</h4><span data-en="Community" data-vi="Cộng đồng">Community</span></div>
+        <div class="jstep"><div class="dot">04</div><h4 data-en="Give back" data-vi="Cho đi">Give back</h4><span data-en="For the community" data-vi="Vì cộng đồng">For the community</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ ECOSYSTEM — NORTH STAR ============ -->
+<section class="section" id="ecosystem">
+  <div class="wrap">
+    <div class="sec-head reveal">
+      <span class="eyebrow" data-en="One picture, a thousand words" data-vi="Một bức tranh thay ngàn lời nói">One picture, a thousand words</span>
+      <h2 data-en="One human journey, five territories" data-vi="Một hành trình con người, năm vùng đất">One human journey, five territories</h2>
+      <p data-html data-en='At the core sits NhiLe Holding. Four stages — <b style="color:var(--text)">Understand → Grow → Connect → Give back</b> — radiate around it, with Technology as the foundation that holds the whole system. Tap a territory to see the brands inside.' data-vi='Lõi là NhiLe Holding. Bốn chặng <b style="color:var(--text)">Hiểu mình → Phát triển → Kết nối → Cho đi</b> toả ra quanh lõi, và Công nghệ là nền tảng đỡ cả hệ. Chạm vào một vùng để xem các thương hiệu bên trong.'>At the core sits NhiLe Holding. Four stages — <b style="color:var(--text)">Understand → Grow → Connect → Give back</b> — radiate around it, with Technology as the foundation that holds the whole system. Tap a territory to see the brands inside.</p>
+    </div>
+
+    <div class="eco-stage reveal d1">
+      <div class="eco-orbital">
+      <svg class="eco-svg" viewBox="0 0 880 720" role="img" aria-label="Sơ đồ hệ sinh thái NhiLe Holding theo trục hành trình Hiểu mình, Phát triển, Kết nối, Cho đi; Công nghệ là nền tảng bao quanh.">
+        <defs>
+          <linearGradient id="journeyGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#E5A92B"/>
+            <stop offset="0.4" stop-color="#E23744"/>
+            <stop offset="0.75" stop-color="#46A06B"/>
+            <stop offset="1" stop-color="#E8607D"/>
+          </linearGradient>
+          <radialGradient id="coreGlow" cx="50%" cy="50%" r="50%">
+            <stop offset="0" stop-color="#FFFFFF"/>
+            <stop offset="1" stop-color="#D9DEEC"/>
+          </radialGradient>
+          <filter id="soft" x="-50%" y="-50%" width="200%" height="200%">
+            <feGaussianBlur stdDeviation="7"/>
+          </filter>
+        </defs>
+
+        <!-- nền công nghệ: vòng bao quanh đỡ cả hệ -->
+        <ellipse class="tech-ring" cx="440" cy="358" rx="392" ry="318"/>
+        <ellipse class="tech-ring" cx="440" cy="358" rx="352" ry="286" style="opacity:.3"/>
+
+        <!-- spokes -->
+        <g class="spokes">
+          <line class="spoke" x1="440" y1="358" x2="250" y2="172"/>
+          <line class="spoke" x1="440" y1="358" x2="630" y2="172"/>
+          <line class="spoke" x1="440" y1="358" x2="662" y2="552"/>
+          <line class="spoke" x1="440" y1="358" x2="218" y2="552"/>
+          <line class="spoke" x1="440" y1="358" x2="440" y2="668"/>
+        </g>
+
+        <!-- đường hành trình (vẽ dần khi cuộn tới) -->
+        <path id="journeyPath" class="path-journey" pathLength="1"
+          d="M250 172 C 372 108, 508 108, 630 172 C 772 248, 778 470, 662 552 C 528 622, 350 622, 218 552"/>
+
+        <!-- LÕI: N — NHILE HOLDING -->
+        <g>
+          <circle cx="440" cy="358" r="74" fill="#E5A92B" opacity=".16" filter="url(#soft)"/>
+          <circle class="core-badge" cx="440" cy="358" r="58" fill="url(#coreGlow)"/>
+          <image x="404" y="320" width="72" height="80" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAckAAAIACAYAAADpMJeQAABW3UlEQVR42u29eXRc2Xbe933nFggOIAoACYBosgnOY09P/TQ851myJdnWYCuxhnhYsiw5WR6XbCceohU7SqRYnmKvZWtpyU5WIsWDIlmKn2RLlmwpsqUna3hDv36vBzbnmQRBEAALBAcAVefLH/cWUGSTTRAoAPfe+n6r2WQXG0DVOWfvb+9z99kHMMYYY4wxxhhjjDHGGGOMMcYYY4wxxhhjjDHGGGOMMcYYY4wpJvQQGGNMqX36cl97Eq2Rrug5rynvA2qMMSaffvpZf24KSyzB5w1PfC7lZfCNMcYs32eqjd/vyd+1CpHoGhwc7H70qKu7vmmue1O90t2o1LsrjWRTTMKmJDY2N8gtgdgaI7aS3KrIbipuQmCXpE1AqFCqICiRUAGYBCCICo+/R0qAIESAdVJ1RNRF1UEuEJoXwgMJs0HxvoIeMoZHMdGj0KjMNSp62BXxYGEBD2a34wHGxh48Y4y4UYJpkTTGmOVnOPGJ/2513s9z4HyK04/L+rnDw1u2ST3hYexlV9LPhnqRhD4Jg0EYilQ/pF6Q/YB2AOwlsE3SZoJdoLokdgGqkEwAdC29nyUZ4BoogvShmKIOqS5wgdQjAQ8gPCAwI/IGpXMC3qXiqSSJF6ampmaWKZh84u+f/Ds9EXxYJI0xpt2JRbVardZqtdpTHG14hl/9SBGtVqt9jcrWXUGNlxExRGIYwpDAAUD9BHtB7QDYD6hHwjaSmwEkBJ/pxZ8iTk/9357zP60kc+NHZINP/6snPoYkCLhL6DzEz4v6dIX135iamrr+Ed8zvuB71Eo/jDHGmCcyyGp18A0w/G1Be0FcJvhWlN5KMP+lu3fvXn2+0/2ayrahD3ZU5pLdCvEwgRMSXiFxCNBLAAdABn5kRqbliC9fwM+vtwYsp2hnKSMkUzVLP/w5Rf0SgZ+PsfL2vXs3J5/4Pklv7+A+hXCc4F6ysR0I24FYF5LxIJyq13FqdvbWHWeSxhjTZpHs7R/+2SSE/ypKSw/lJAi6QvCLAN4TdF3CLMl6UOxuIFRB7KS0m+BeEPsk7CLRw2xv8wnxe5rwLadwp4y0jgMBkgQk1SWdAfGWwEsBeACoX+AxSB8nuZskhSez0zgH4BLEawR/6O7dW7+OD2+hWySNMeYFIABVq3v7FR59geDezKmGJQHl4rM8Lale9tV8wlEv/V8tv1q3De2Tn01cHPOWcW0VQ0lPE1i0zlUIRD02fuTe9O3vXY5IVjzuxhjz0SIZw8PjAeFlLBXrtPhotfjmJ0Ru6a+EDxfuWBBfPKNPxzId18Ux1YcTv6eNrwDVJYQAzC43KLFIGmPMR4skiOR1EomkBoDkib/P0zO/TpkTrvDrQjp/nHpRZTbGGPMs7yq97lEoT9Aj6IZF0hhjVk8DAEUd91AUHgEIkhYY4wctr1kkjTFmpVlHT8+unRAPZ08X7TOLL5WTCwu4ZZE0xpjVEQCAm3SAxKCHo/jySBIibj14cOfOCy0CY4wxz3CSDRwnWUG29eoRKXAOmXIJwEKmf84kjTFmdSqpIx6E8kDoNxf/6EzSGGNWl3lIOOyhKEm4A0ENvfdCX+RxM8aYpyQcQATe7CK5/0UyD5PbgIeQHnR1Va60BkEWSWOMWSFbBsaHAI1mla0WySKLJAkIlzdtwlWLpDHGrI4AAN2xfhDggIej+CKZtU66OJZe7Lzsq7IsksYY8yzPKh0m2WyC7Uyy+OnkhRfVPoukMcY800PqjUX/asqQTl584SXgYTPGmA8RAVDASQ9FCRLItB1dQ4pfeNGgxyJpjDGPQwDq7+/vBbA/u+vKW63Fn9M76uI5i6QxxqzeoWIhbB6BMJj5U4tkgTNJkhB04/7t25Mv+sUWSWOMeYpIdkUdYAjb8PiFyaaAIplOKt8DUMcy29FZJI0x5iOIsXEyU8bo0SjFjL7fGgRZJI0xZhWZBwJf9VCUZ2egQZxfyRdbJI0x5nGHGgF0tVS2equ12AFPiIrzSaPr4mNBkEXSGGNWlnX097+0i4Db0ZVCJAmClzZtWjhvkTTGmDaI5AI06nZ05RDJtGWrzk5MTMziBdrRWSSNMeYZVFQ/QLK59epMsvixz8WVap5F0hhjniAiNIt23I6uBDsDhE6t9BtYJI0xplUfAZB43UNReJrt6EQlH1gkjTFm9VmHduzYsR3AAbVkIqbISqmaFK+tdGfAImmMMS2CGGNlFNJuuLK1+PpIguLE1q3htkXSGGPaIJKSDjKEzXA7usKLJNN/vfeiFy1bJI0x5hnEpSYCbkdXCqnU26vRO4ukMcZk7hQAAsNhD0V5dgbAxeuxVoRF0hhjltrRBVFHH3OypqgBT5C0gMALFkljjGkDg4ODQ4g44IuWS6KU0nic46XsP1e0fW6RNMaYTBDrdRwEFy9aNgXWR5IgeG12dmzKmaQxxrRBJBvgqyQD3I6u8CKZzerFbC5f6KJli6QxxjzVIfLoY07WFDz00edbgyCLpDHGrIwIAFGLRTum2FlkIkkM8e3VB07GGNPh+QYA7dmzZwuJfW5HVxal1IwWkqur3RmwSBpjLJIAZubmdkt82e3oiq+PTC+RvFardd2ySBpjTBtEEvXkEMkeuB1d8ZNIACDPAtcfYoXt6CySxhjT6lljPMZUGt2OrhxSeakdOmeRNMbYnQIg+IaHojwE4Eqbvo8xxnQszXZ0CYOOt7xmCqyPkqKkUxZJY4xpA1t2vDwMYL9ctFOGXQFCulPvxnutOwUWSWOMWVkmia6Fhd0ABzwcxRdJpg+Wr9y/fftO9tqqnjFbJI0xHS+SSRIPk0zgdnRlyCSb12M12qFxFkljTMcTgVcec7Km6HyxNQiySBpjzIr1ERB40kNRCoIEROlM276hx9QY06EQgHbs2LGdwDHfIVl4mkU7Cwl0pV07AxZJY0wniyTm1LUH0MuLxyVNgUWSEHUjxu5r7RLJisd17Y3wGRGPMSYH9smoQ2DYgrRpq0WywCLJtAHde7WZ61NYZTs6i+T6GKCe8/etv1rF81m/G2PaTKAOk4SUNhXwiBTd8fJcc2qRVrhaJPMa1QwPD297+LCru6vr4cLk5OR9PH5eRy8ofqFFUPWU72EhNeYFbRQAJJyk88fS7AxE6Gw7v6lFcg0CUwCxr2/w9Udz+CmEhZ56rMz19g/XCEWIC6DqEhYAXCZ5Q9I8hYckzpOabITkEULjbnxYubt9Ox6MjY09wPMPxBIffsasFYixMZ1CBFAheMJDUQ7fK0lB8VQ7v6lFcq2iGfITgeFYdjcdArO/yn5vjVzZ8h9RAqOkRrgXKvHeg4ea7e0fuknhjogxgjWJtwLw/gJ1p5sL16amph4AqH/E1kIzC7V4GrNkp9o2NLQD89jfNFMPS6F3BSigBoXrrTsFFsn8WuAJQBFQA0AifWhCH5vcJ7JBkugF2AsSATi6qK8ASEASEmiurspYb/9wDdBVijdAnQN1mTGZlHSlVhu/AWBhGdmnhdN0VNYBoBEWdBDkTle2lkEkSUITta3JLdQsknkmAggCXmFqiFpBhJpNrgQh++fDRk6wG+C+NBHl680sFQBEAcR0b9/QDRCnQV6FdJaR5wBdDmFhcnp6uvaM7DOxcJrOsNZwhAkTSdGZZMETEwIx4irSx1NtqWy1SK5JAgn17tnTz/sLx7IbBcIKv89yIlsByn7MYwuiWeDTH0LoR7PlFgkFQeJMA113q33Dp0C9LeBdNHghRl6anb018RThdMZpSupYdTIzM6/nwmeSAInfbt0psEjmVCTD7PwecV1uFOBzhFSZhLY6gCTdyg29DNgL8BsIQIliCBrr7R+6gIhLCPgdkF9Avev8THrm6MkFF1qiNYumKVwOmTnVox6K0vheCIvXY7UNi+RaTFTQYSJ052AL51ki2sxA1ZopktxNcjcSfDWAPykpKszf7O0fPgPxCwGN9+sh+ezs1K1zSAuFLJqmsMHsnj17ttybnT8kLtmuKWwWmV60TFy2SBZhxhQOZwWryrGT4HOEM8s6wx4Se0B8HZAgxPiwt3/4NKAvAfiMyLdZ7zqXZZsWTVMYkaw9ii8TfJm+aLkUUyrpVpzHpdadAotkflXyCIp3OnlZwklyC8mPAfwYgO+WBCXzV6t9Q79F8Ddjws90h8YHExMTs098r6Rl8VowzUavdST1+jGF0AO5HV3BiSQSCZfu3x+/40wy34YXkW5bHm41xoJ/pg8J5xPPORMi7E2fb+KPMqo+H8OVat/QWxB/KcbGb927d6d5AerTsszopWM2xLMCr2Xl525HVwoPrAtNH+xMMsc5ZE/PyA4oHixxqvSkcD6ZbVYAHmTgQQD/NRnuV/uG31G6NfvLIW76nVrt6vQT3695VMbbsmZd7DTbFXHRTrlm9fxaJCcWyfYRADQqlYXjYjKc3SjQCeeuPko0SXIbyU8Q+ISEv6zw6Gq1b+gzIv5jZPj12albHzyRZSYWTLPG6zXNHKXDcNPWUvje1NvqM2vxzS2SbaYB7k/IIKWddjrUCT0mmi3bs6G5NUvgOxjjg96+od8h9R8Qu36lVrv5Lh6vmrVgmjWhZ2SkHw/jXrejK8WuAAXV2AjnWncK2pn9mHYOKHnMo/Ah0QyZ4BFQlNSQ1AC5NYTwtWTy9xAan6v2D/1Ob9/Q3+jdsevjWQDXwFKhT+L1atrl85IHGAUx6NirBCJJgtKtrVvD+FqIpDPJ9hGzGTvqDZxlB2bKzpIC6XGTN0m8qaj/pbd/+F0C/w6x8ala7c4XsbQl2xRdV8malRsr9UogK3A7usKLJAFE4txYm9vRWSTbny0JOLGJutM8/mGtXN64JS2C2dxWrQTyYwA+phD+erV/+LMAfiHWG596olLWx0rMChdePEGEZ/VFNsWTyrMtQXijnd/aItlGkaxWJ18S+TJ8OHmlY8gPCyY3kfwkgE8ySf5GtX/o10D+m3nWf+nh5OTNlq9vPr/0kRLzkUlktthe8VCUyn1cWKvvbJFsn4MHoIMEq3j8+ivTJsEksZ0MfwjAH9oUk9ub+oZ/FtLP1Go7fwM4Nd8SSdLZpXlWMDs4ONgzX+cRPWa7pqAECRAXO+20/wd4jNuY8Qd+eXaBsrOZ9jq2ZuGPFot+wCEG/hkE/n+9/ZOfrfYP/ZVqdXh/NvYNLBX72Amax4LZRiPZK+kl7/gU3+UCIBTvdDF5t+U1i2ROJwuAjngo1tzJJa2CCQCBfJ0M/wBBn6/2Df1UdWDo67H0bMKVseYxkayrsZcMW+Edn8L73SwpuTA1deOmRTLfhhez3w94ONZdMCGlx0oADjCEPwLxV3r7hv9zb9/w927bNjSMpaMkwWveBPJo1kPAOz5lSE7I1nZ0Fsm8Uq2OVgGMZoeTHZ2us9/7UHYZ+IkQ+MNJFz5X7R/6O319Q69lhhRbBNbz1IFONQqveShKNKnS+607BRbJfGY0qIdHeyiONNtCeljykV2S4WUyfJ+Iz/T2D/2znv6RT2bO0s8tO48IgBSPr6VTNesaHIPCqTX/IWb1IlkJOoTA7pZMxeQiu1zcit0cGL4rQfz1at/wL2/vG/6DWOrqY7HsEIe6defOXQD2y0U7ZdgVoKQFQJdbdwoskjkVSTVwkms4UWa1Yrm4FRsY+PsC8fPVvuHf6Ovb9V3AiU0Wy86w06QR9oEYciZZGq28293NMYtkvomZuX2ZhyL3TrJVLMXAr0LAP6v23/nN6sDw94yOjm62WJY8Yoo6SrKt9w2ajVFHkhBw6vbt2xNYg3Z0Fsn2Od4IoAvgIUenhRJLZs8tIxk+TvDHpmce/VZ1YPi7gZGtT4ilKY1KhsNrmXWY9RPJzJjfw1Jl69osGY/1qh0u+vtHRgjt9nOO4rlMAKEploH8GMEf7+2Pv9XbP/THsPTMkhbLwpNdQADf0lMmpRQ/WA8nYVYpkgvAXoADziRLI5avk+H/qfYN/8b2vqFvwVI1rM9ZFtdOBRzqphYbfthOC26zkoAQz1kkC0AS4yGmrR/8nKMkYgkpMvCrAsO/qfYN/7u+vp1fg6Vzln5eWcBgtlqd2S1w1Ds+xU8gAVBAjQ2eb3nNIpnbGaNOrPVEmQ0SS0gM/CYx+dXe/qEf6+8ffgV+XllIkVQIR0huh9vRFV8k04uWx7ZuTW5ZJPNN89qdVz0UpRVLZtWwSWD4nobw29X+4R/Yvv2lHVh6Xmk7KoRSxhNuR1eSvCT919haXbRskWxfdKpqtdon4mi2hePxLCeLR0dI9JD8/lBpfKavb+g7W4Ilb8HmOfMAIPkOyXJ5YL69Hjpmp746kUQ9bN5DYI+HoyPme+mcJXkQDP+i2j/8H7YPDH8lvAWb53nLdnzoW3pK5HshfX49fphFcpUTVYk6BIQu+DlHZ4mlFAVFkr8vCP+pd2D4H7RswboKNmds3/7SDkGj3vEpxa5AkNRAI5xr3SmwSOaVIF+706Ezv2iswJaA8FdCpfGfqwO7vgOPV8GajZ8noKt+mOSIh6M0+cntRiNecyaZ/4gGAk96KDqabAs2NkgeI/DT1b6hn6pWh/fDhT35UcoGT5BMWubEFJNIApAu3r9/e6L5mkUyp5MFIFCL7ehMZ4e2yWKbuxD+CAJ+s1od/u4smHJWudETFFyBXqr5JM5hjdvRWSTbkO9v2zY0COqgn3OYFnvKtmA5woQ/Xh3Y9dMtWWVwFrMhwSwkt6MrEwKvrpeG2bGvYty6upIjAHfATQTM4yRpEawige8Q8Rt9fYPflTlsV8CubzCr4eHhbYD2qyXANcVOUAS8v6iXFskch6hsnMyec/iiZfM0Yw7p2UruRkj+WW//rh/bNjQ0nGWVPle5Tg710SMNC9wNt6MrfgIJBCk+6grhHYtkIabMzyPNsrLKrHE6vqeywE9XB4a+PhNK2+A6iCQq2E9iG3xMq/giSQLgtUplsbLVIpnXJBIASB31UJhl2lkzqzwC8Rer/cM/mL3uop619qxpZasvIChDWgJAwtXx8fH7WON2dBbJ1UWn2rNnzxYJBx6LWI15TlaZNk1HF8n/qdo3/PPV6vA+LG2/mrXxra97DErkgKkP1lO/LJIrE0nMztaHQPqiZbMSm0v7wAZ+owJ+rbd/8BuwdH7Pa6l9dpoFHzzuYLZEIQ90ar0N1qxAJJXEQyR64eccZmVrKMm2X0eJ8PPV/uG/nq0l2S7bx+Dg4CChQw5myxFgprO4eIekRTLn4cxrhJ9zmFWRIN1+TUj+vWr/8L+oVqt98HPKtgWzj+rcD3KHh6MEHhegou5pIV5uec0imdPJAsQv81CYdtlgllV+J8LmX+4Z2HUcfk7ZFpGkcMDHtMrhd0mC0Ol79+5csEjm2/CaxrbPw2HauK6a269fnkT9am//rm+Az1OufmDJY+vpUM0aJyfkGSy1o7NI5pXe3j39gvZKSxGrMW0gye6qHCH0c739g38OS+cpvc5W4FQF+AKCUqWTOrfe9mCRfPGIH+TcXgK7Mju08zJtFUpAEUB3YPKj1f6hv4Ol82C21+XbaRwdHd1M6bjb0ZVjTtMKyXBqvX+wjW4FIokEh8iwCX7OYdbOLtPerwzfV+0f/hdp/9H1ufWgLHY6NXV/r9vRlWZXIEBaQIMXW3cKLJL5nbJX13uiTEc6embPKf/4o3n87LZtw0Nw5evyg9kKDgZyO3xMqzRxT6OhdWtHZ5FceUQDyRctm3XzDImkOsnfV9mEX+zr2zUKV74ujxiOZdLoY1pF97sEBNycnb11d71/uEXyxRxW3LNnzxaCr/o5h1lHKplQvino3/cMDJywUC7DYMkTHoVyiGS6rYLPAljI1r0zybzm+/fuzY8I2OXnHGYDhLLBwGMhdv37anXkTQvls4NZAAR1wMNRJqWMX9qIn2uRfEGRBLg3a0dnkTTrTfMs5csI8d/19O366kwoKx6ax/1ptVqtAjjkY1qlICh9qnzBIlmM6Tqc3rqzeH7NmHUVSkANksMJ9a97+nZ+DYC6M8ong9mu/QRf8jGt4gc8SAvYZlDHunbasUiu1ALlOyRNPjJKkDsTJp/q6xv53c4oHxdJheQoyQp8TKvwIpm1o7u+bVtlzCKZb2I6O4vX7hizsRmlFEEOiPHf9PcPfjLLKC2UqSr6mFZ5MkkAvD42NvYA63TRskVyZdGpBgcHe0AeaY1YjdlAQiaU/RHh53p7h78C3npNg1nBwWy5uLhRmmWRXL5IYn4ehwCM+m46kzehJLkDAf9vf//Qq+jcqtdmlrEJ0GEHs+XxvRHxtzbOwMyyJwrAAZJd8HMOkzOhlNQIgS9H8Weq1eF9mVCGTrTTvr5dIyR3O5gtPMrW9kJQ5VTLaxbJ3M4YF59H+jmHyRtJdo7yqAI+NTQ0NIzO6/WaFu1IBwH0w+3oyiKVk/XNcd3b0VkkXzyiab2bzpjcCmUgP/ZoAT85ODjY02FCwSyvfiM7puV2dIXPSwgAl+6Pj09u1JuwSC7P8NKIXHLRjimIUIbfO18P/3u2Vtkha7ZZtOPeyiVKTgSdwdLjA2eSeWXr4OAQiH1+zmEKIpR1kn+82j/0Q1jadi3zul1sR8elY1q203JwbiPn0yK5PONDUscBgEMeDlOkjJIM39fbP/Rn0CGFPD09u3YK2Ot2dOXxveDiHZIbgkVymWNEhY+1tKOz8ZkiOJggSQT/UbU69HUo99GQNJhNGrtJDLu2rvAIQIjSwwr5pZbXLJI5nSyAOOShMAUUDoHcDPKfV6vD+0ucUaaBa8L9bkdXDr9LEhSuJUljwypbLZLLI6aZ5GLRjjFFIiA9GvISiJ/YsWPHdpS44lVxsWjHqWQZkhPo4sTExCw2oB2dRfIFIvERjGwFsO+xiNWY4tA8Q/mJhUbyjzNnUzbbbzrQ1z3dpUonT2+0Vlkkny+SeFBt7BL4sitbTcGFsh5C+J7evuG/gHI9n8wqW0c3AzjmYLY8vpfQ+xv9RiySy5gogPtIbIe3cEzxhTIS/Lvb+wd/F8rzfJIA0Nv7YDdA91Yuie+VJCqcs0gWYbYSvNLSwcPGZ4od9AX0BIUf6+3dM4BybL2mn6vCAyRL/cy1Q8jmTw9jV+NGy2sWyZxOFiR8uYfClIRmIc9RJgv/uEVQii8qkcfSWNbt6Irud0lC4NmZiYkNrWy1SD4/Os3a0fn4hykVWaMBfmdv/9CfRUm2XcXF67FMCZITAqcAzGGD2tFZJJdJz8jIAIA97uBhypZRSooQ/15///DJggtlekwLPOFpLZFSCu+1JCwbZyieio/MJJE8WHgZSx08LJKmVOs7BPZG4Edx6FB3HhzSCj+HqtW9/ZCOZEU79muFD+AAhng2F2/G8/HRTkQhOeqLlk2Js8kGya/uvTPz11DM+yczsX+0h4R7K5cggQRAKT4K4tmW1yySObbAY3mYKGPWUCgjie/r3bHr4yjetmtads5wlAzdDmbLIJIEiFsxbr5ukcx/RAMBr3ooTLnjQIgM29iIP3IIxdx2VXQwW5oFSYDAeK12ddoimW/HEYeHh7dROqkCOg1jXoCsbV34yon+e38Zxdp2zYoFoi9aLlFyAuCt5trc6DdkkXy2SOLhw7hLwB64g4cpP2m1K/A3BgZ2nUAxtl2bx7QSEAc8heXxvYj8Qm4Mw3Py7IlihftJboM7eJhOWfPk9kaM/xAF6uu6devgIID9rmwtTbCmRohnLJJFyPuFQy3t6IzpBAfVYAjfsL1v6I8h/9uuAQA2bdJhgDvg55GFd7nZ79MVJRveacciubzQ2oeTTcctewkK5A/09IzsRAF6u4rhOMkAV7YWXiTTdnS4dvfuwJhFMt/EbMp80bLpuGwSUCR5IFTi9xUkO3vD01aiTFK4CJyaxwZetGyRfG4CCQ0ODvaIOuJ2dKYThTK9Ukt/tq9v8HXkc9u1WbQDLZ1lNiUQyQBcyZM+WSSfbnyYn9dRgrvdjs50aqDIELaJ/Fs5Xv/q7++vAtjvYLYcwVm2/L6YwzdlnhRJheQwyU3wcw7TmSTpkZDwzf39O78RzaMWObPTBXbvptxbuSRZZJC0INXfac0sLZJ5DWmkI3maKGM2RIkIRoXvzxqg5+koFAGgEuNhhrDFwWwZRJIQNAZsu2SRzH9EA5G+m844VpQiQ/jK3smZb0MOn03GgNcczJbD72bt6C7XaldmLJI5DpzR3FaSL3A1ZtEwhL+5Y8eO7TnK2NL91Qi3oyuVVOoUcra1b5F8CtuGh3cAHHUxgDGL2eTxhUblu5CPc5PNYLZL5NGW10zRg7EQPsidAXhaPmR8SBawD8TgUkWyMQ7xCXzvwMBAb16yyYGBgWFCL8u9lUvjexF12SJZgImi9BrJBG5HZ0yWTUIMPFqPXX8yB9lkAIAYw36AA/DzyMJHYABCjHpA8kLLaxbJHPuEN/I2UcbkwZkR+vODg4M9ucgmA/czba7sytbCiyQB6OL09Pg5i2S+ydrRydfuGPOhbFJiCMfm6vgTOcgmESNdtFOW4IsAiLMA5rN1ZZHMIQSgkZGRraAO+KJlY54a8gPi925wNhlT4+RrnpFSOeCzyKHftUg+LpK4X6+/JPElX7RszFP8RVbpOlcP37RB2WTaWxmDPSCOOJgtj+8V8G4+F715bKI4H/aS2A5ftGzMU5NJAqDwFwF0bUA2mbaj6+MBQLsdzJZicyJIagjIVacdi+SzPcAJX7RszDNJJAnE7+rtH/zaDcgm06xDOECGvLXKMytXynt1brpqkcx/RANAb3gojPlIIklS/O6Ncmri4oXoDmaLnpekScmVh1Ob7+TxDVokl6LTCIDEYi9IR6fGPMNvKD3B/19u6x8+ifXt6drsg+W2keVKTt4Czs8hbUfnTDKv9PSM7AAw4g4exjw/qGQIWxLpu9YxqFwKZuV2dOWKuvBObt+bp2fJ0JKEL4Mc9nAYsxybEQh+W3bxcWO9BGvHjh0jgA7JrT5KoY/ZcrpokSyASCo0jpDciIo9Y4oX/AuRgQel7m9ZJ39CAJhXshfkoC9aLjwCwBg120iSsy2vWSTzq5TxRF4nypicOjmI+k4sbYWuuUgGsLUC3SJZ5PVDgsD1zWHhhkWyCMaucMJDYcyLZJOCpE/2DAwcxzodB1GEg9mS+F2m/7oxMTExmwU8FslcJpBAxKFD3SBcDGDMi9lOI4SwNVHXH18H20nb0VHHPPRlWkQ6nWc9skhmRr397t1RSAdd2WrMi9lPtg3z7Vk/17Uq4MmyjEPdEvY5mC2P76X0mTy/SYtk8zmHkj0kt8IdPIx5MR8iCeSRuQY/sYZ+hQBQrd57CaAvWi4+i+3oYgxnWl6zSOZ2xho85nZ0xqyItANP5LevobPLKtB5lGSvg9myOF5NdXXVr1skCzFZ8agHwZiV+ZEss/vm3t49A1ibqtN0aw7xRBrLOpgtusfNkpLLk5OTt3O9uD1XzWIAuhjAmJULWGTgblbmfu8a+ZaYxrLwHZIlEcls6ZwHUEfOLlq2SD5u3NqxY8d2EM0OHt7CMWaFTo/iNz3uBNsqkgkJB7Pl8sDnW3cKLJL5FEnMqetlQLvdwcOYlduSJETg66vVaj/au+VKANg2NLQT5GgWzHoXrAS+N0pn8/5GLZIAgvRadjedO3gYs3JfIiLsBbq/ps3+hQBQmUv2ABh0D4FS7DqEGOMjhfCFNdp5sEi2dRCkQ3mfKGMKQCQBse1brq29lRMHs2UQSYLktS1JI5cXLVskH49oIBftGNMWMUvPZeirMTKyte1ipvCGg9ly+F2mrSEu5bkdnUVyqSFzAulwa8RqjFmhTaWNBQ71PVx4s40+Jj3uwXjSQ1yq1fJBEXSo47dbtw4ODgLY5w4exrQn8CSZiOEb2/g9NTg42EPhoCvQS5ROQh8U4X12eiaJpMF9IHd4yRrTPruC+HsAVLD6Xq4EgEfSSwJedgV6KQjphgMuWCQLYMyhweNZMUDDxmfM6u1KEgScrFaH9j4mnKsR3UZymOQ2uB1d8RNIgIAeNpjkuh2dRXIppvm4160xbQ0+YwjsVeDH2yCSAIBEOuTeyuUQSZIQeG52sv+iRTLfxGzKDnndGtP2bAGAfn+7nKDA4x7W8qwNSh8Ap+aR43Z0nS6Si8UAIPa7GMCYttsXKHwVRkc3Y3VHQdIKdODVdmWlJg9SuXjRcu7ns5NFEnNz2CVhxMUAxrTXvrLnkgf7ag+OrsIZEoB6enYNADrsCvTy+F6F8EFR3nBHiyTJUZI98OFkY9ptXzGEsBlI3liFSAYAYFc8BHLAw1r8/BFpZes8YzjX8ppFMrczFnSk5W46R6jGtNchQtRXrNYZhshjbkdXqpVxp9HQNYtkIcLd8IpXrDFrlk1C0FchPS+5coELOlIUh2o+Wh5JQtT47OytqaK86dChxtvIPvtrrQZtjGmfnUkCgaO9g4P7VmhnaTYKHvFwlmd3geLnWnywM8m80tOzawfki5aNWcNgNJJhGxsrei6Z9VY+sQnAQQezZVLK+KUizWenZpIIYWEUxE7v4BiztpkDpNdWaqd9fVMjgEZd2VoKggQw8Gyh3nSniiSS5DDJ1T0rMcYsRymbt3fEF7XTGOMRIvTB7ejKEDBRUE11XX4siLJI5lUpeaJIE2VMYQNS4DAwunklQhcCj7dUoJsCiyRJQLo+07+1ED1bO1kks2IAuM2VMWsskpJA6cD2nfdX1Ow8Aq5AL5HfJXEJV648Qs4vWu5kkVwqBpCOaQVGa4x5MXtjCNtC5Iu0lWtWoBOUeyuXa0lcK5r2dKJIondwYi/Al+FiAGPWJ4NYQYPyHTt29BAcdQV6eXwviM8V7Y13pEiigQMM6IWLAYxZF6J4tFU0l2Onj2JlryT3Vi5HoBQk1VXnexbJYkzZQcJ30xmzbtGpsD/zN8upJicAVKgjIYQtDmZLw51GQ1eacZNFMtfppO+mM2a9fIwEiNpTrVaryzZRAIzhtaI5VPP0tCSrbL1y//74VOEWcIdNVmZsi1s/xpi195GAsDPGbYOtIvg8O42IrmwtzQIARJ4BUEdB2tF1okgSgPbs2bMFwqgrW41ZP7sjwzZW4oFliGRWgY4ucrFnq+20HHxQxPnsNJFE7VF8GZArW41ZPyIJKMbjy7XT/v6XdgHa7XZ05fG9JC8U8c13nEgm9cZRBG6FiwGMWV8D5GKXq+faKaC9wOJFy7bT4iIAIcZ4vwG81/KaRTK3IS34hitbjdkIldTwohk+N/WMR0jSdloCkSRB4Mrs9u5LFsn8RzQg5bvpjFlnecx+2wtgE5axi6Mo91Yuid9NH0rjQtHa0XWaSDYj0gqko48brjFmzXNICRR29vTset4xkJga57K2Zk1xpPJsUTWnk0QSO3bsGALhu+mM2RhP2U+G/o8IUglAw8PD20BfiF4m30vF94v6ATpKJDWf7AW405mkMRthhdyiJO56jkhiYYGjkPa6HV3xoyKk7ehE6kJRP0RHiWSjgldIBqQ3DBhj1s/+IkgmigPPs9OFGA+BYUX3T5ocKqVwX0qutQinRTKnEQ0InvSSNWZjbJCpx9n5XKdEHvNFyyXxuyRAXKz1bR6zSOabrM2V3vC6NWZDk8r9zwtmJVeglyowgr6UVbYWqh1dJ4kkAWjHjh3bCe5xMYAxG5pbDHyEnUYAgYB7tpbKAfP9ljkuHJ0ikphn94jvpjNmw2n2b41Ps9MtAwMjIA5nFejBw1VoQupt47lCf4hOEUk2FvaTYRtcDGDMhtmhoN0AKs+yw0TJPoD9Hq4S7BkAhOKjoHC25TWLZH6nLBxxMYAxG2iCAkh2Yc+ermeJaAKezNrRNRzMFl0kCQG3Yuy+YZEsxid91evWmA13nT09dxvbnv3XPOZBKsdMkwDFsVrt6l2LZH5ZKgaIcJsrYzbUFgUBveTC0273SNvRCRbJcqWT72XiWFit6QSR1JYdO3aBOupiAGM22CCJTSFs2vY0Ox0ZGdkKYL8vRC/TfOuzKPh8doJIohKTUd9NZ0wuqMSk3v00O703j72C9vlC9FKQSEKATi8llRbJHOf84VDWjs5FO8ZsXMAqAIFS3xMBa3Yhuk6GEDZndmqRLLDHzX6bAipXi/5hOkIkAxevx/LddMZsoPNMC1fDU6/LUhKP2U5LIpIkBFybnh675UyyABGNsCiSxpiNdjqK3U+zU0ZXoJcmGEp/PwdgHgW8aLlTRDKrbD3UDdAXLRuTl6CV3PRhO0UFwCHbaalm+2IZdKbsIom+vtldAPb6omVjcuI7xSczSWwbGtoBco/ttDy+V9B7ZfgwpRfJBnGCZBVuR2dMTkRSXU/aaWUu2Q1gh0enFLsFQYrzFfKLrTsIFsmckjAeyZTRla3G5MEmk9D7oawjNI6SrMCVrSUQSULAWIxbCnvRckeJpAQX7RiT30yyqZSvlcGhmrQdHYCrtdqVWhk+UJlFMqYWR1/gakyuMw9XoJdQKk9nc5s4k8wnLRctY78vWjYmVx40abHTCLzZBYQDLa+Zojtg6VRZPkuZRRJz6trji5aNyV3uGFrttL//5gghV6CXyPfGwHNl+UClFslKjIcZwha4GMCYPGlk5ndOpA41xoNA6Icr0Is/tUBQjI8q0NWW1yySeSUCb7AkE2VMiXzp434n6KAvRC+JSKYTeXF6uvesRTL/EQ0YcNLr1pjc8WS2+IaHpBx+l+m/TgPn5zJ9sUjm1AAjgATC/mcYpTFmw0XyVCP1QXzdQ1KmyQ1ny+R3S7vdunXnziEAoy4GMCa3NPr7+7cL2usK9PIEP1J8r0wfqowiGQAgaYR9AHd63RqTX6SuUQLDrkAv/lQCCJLqWKpsLUUtSHkLdyKPtly0bOMzJo+eNYSjZOi2nZYm6pmqP4qlqWwttUiSeKVME2VMiWgs/UlNO3Vla8HlkSRE3njwYGKqTB+sjCKZRqR0xZwxeU03WjyQ75AsyaQCAIXPIr1oufDt6Moqks12dD2ADrgYwJhcMgsAJ3Bik6BjskiWSCnju2X7TGUUScyj+yUKQy4GMCaHRsrwAABuVO/sAXgArkAvjZaIyUWLZAFEkjHuB8M2uM2VMfnLNqS5zFxHCfTBmWTxE0iAMWoW9XCh5TWLZH4j1XjMba6Myat96mH2x1Gmhmo7LbpIkiBwc/PmhZsWySIQedzr1pj86SMAUHgIAKKOl82hdqpIZu3ork1MTMxm82yRzCnN0vJXWo3SlCBSNeWZTCUPMuN8xaNRKiu9VEZdKdOHIQBs3bpzBMBBt6MrXwZiij+PksAuTWaRzz7Pb4kml/pcGT9X6UQy6Q77QAx5yZYl69AjCTMeiVLsBhBAfaGhyd7ePQMkRhzMlmJeE0mNCL1Xxg9YOpEksJ9pNYDbXBWbSBIEvwDiiy7wKI1PbXSJszHUXwHoi5bLM6/Tm0K83CKcFsn8hjU8WsaJ6tAIFQJ+m8J9D0dZdgZQr9d5PzCecOBTjinN5vHy5OTkhEWyAE6V8kXLZdoZAHVexC4PRxnskyA4s2N20ywUDnhIyuN3AZ4GsICSXLRcRpFsbq92kTj8mJM1RTW8EGOcDwqnIG32kJTASAkIuHsFVx5BOuIRKdMOgc6U1e+WSSRRrQ7vlrDPxQAlEEkSIG5Iukayy3vnZRFK3R8eHt6GgAMOZsvje0FcKOsHLJVIKsRjJHvhYoDCiyQBUDizdWsYF1TxE+ZS7A4A4p35+fkdEEYdzJZiTkOM8UGF4UuPzbNFMq9KGV51O7oyWaDeHxsbewQx8WiUw0IlnGmEMEyi15lkCUyUBIkbU126YpEswowJfs5Rpp0BJO/AR3nKNbEB9xCTN8kAtF6+bArpclND5SWMj99HydrRlU0kIwCSOux1W451KSki6AyArscu6TWFTjwATUP4uE9olSny0ekyJl1lEkkCULU6WhUw6gtcS+FJAWhS87wIDG/yfJbH10ThNslR2E5LZLDhVOkXbglEEo1kboTCLl/gWnybSw8n8+rs7K071ermLk9nSfINCYF8CcABB7Pl0A8JYIwXSv0hyyKSlRiPMITN8DOsUmSSAq4AUIwLSfPRhyn4xEqPBLwEaZd30EthpwTio1hpXGu1XYtkTolL1+7Y+koR+ehs5ljpOS1H4ANwnsJRkFvhTLLwc0oSEi7cm+wpbWVrWUSyaYAf87otiT6mXATSaiyLZDnmlMRWEV/l4ShP4EPgPeDKI5SwHV1ZRDJrR3diE+gOHiUxvCBJAToFACFUIuhzryWhQqDPw1Aqgz1Vdr9bBpFEf//dYcIdPEpkepNk9+VUJO9Fgj5PV7IMxJRjdwDk2bJ/0FKIpBT3A+j3ui2+AyUJgVenpq7fSkUyRDvWEjpXU/RAJ0hxnjGeLnvwU4rCHQUdyi5abtgIi59lEPggm0tMVioRbjNoTM7slBBwK8auUle2lkYkGRcrW00ZLFBaes4x3hUhRYc+xuTI5xIgcOvevZtTZf+sRRfJCICiRbIstgcAXLqbDsDmCPf4NCZnmSQA8K3sz6WtbC26SGbt6KpVQUezs8nB67fQhhckLQCtd9Odb4hccCJpTN4MVl9qDW4tkjnNOpJky0sEBl3bUQaRJARdD6F+qXW3gNAjD48x+dENSWDkmY74sEUXyQXVR8GwBb5oufAiSQIQL05PT9eyuSSAKHC8Jds0xmxoMAsKqEnxWifYZeG3J0MMxzJldAVkCSD1/pNrk8J9j4wxORFJEpSu9/dvvWGRLEb6cdzrtlS89+Rugag5D4sxOXG5qWVevHLlyiOU9KLlsohkeiaSOuJ1WwoSSaKS0x/KLkWLpDH54kpZEq2yiiQBoFrd2wfhYFbZ6ueRBY5Os3899TmHgFkPkTH58b0g3+6UDxyK/L5jfHSU5MhSoxZTVJFk+pxjrFbbfOtDIind8BAZk4tgNkiqo5G8/aSdWiTzSIJDJBP4ouWSZJI8/dRrd4iJx6JYY8wG2SkB6ZYUSn2HZGlEMpBHO2WiOgES7z9tXSbAjEfHmI0XSaZVO1dmZq7f7ZQPXVSRjJkynvS6LYc+ZvP57hNBT7qPTk0qvQet1O2vjCmGUupM5oMTZ5L5dagC0A0tVrZ6G67ANof0OcdcUDzztJ0BMpkGfAzEmHw4YH3QSZ+3qCKJanX4JZB7fNFyScxOmohx7qkdPCTOAnzgcTJm430vIi9YJAswUUriYQJVuB1d0YlMG9BdnpmZufuULBMxbpoRVFvalTXGrDMCEGKMD0LA+acFsxbJ3LnW8GZ6z7Lb0ZWE89lcfui5Y6227QHAGh0KGbNxIkmCwKXp6dtnLZL5j2gQoENet+WB4KnWnYLHObUA4F4nGaYxefO7aWErzwOYQwcV0RVNJJllG4zEQa/b8qxBCqefERA1C7WmPFTGbLBSanGrtWP2dQq53VqtVqsARt2Orvg2B4Axxof1wGc958jWqCySxmxsgoIAvtuRUXzhJips3k1gl9vRlUEkCZI3u7lw/Rki2Xx1wsNlzIYFs0FSJBsXOu3DF1IkJR0Ew2a4srXwxpdetIxzk5OT9/AR1+6Qi9s8xpiNUcp7QFezHV3HFEwWUiQj8IovWi4R1Pnnrkcubrc6KDJm3YNZAsCV6emujtvRKZpINgAgkB/3ui2RBYqnPzqABcTkqqQG3JrOmA1IIgECX8wuIEg6yQaLJJLNrbhNkg47qyjH+pMkhHjuuZNf14SE+x4yYzaM9zrSSRVMJLN2dNjtdnSliE4pYCZR5XRrxPq0KLZSqU+SuO2uO8ZsjO8F44VO/PCFE0mSowD7nEmWQCTTDh5Xpqf7b32ESAIAJicn7wm6kXXdsUgas37BbIgxPgwKZ55npxbJPMwY42GmT5FdtFNw48tKlc8Ap+bx7GeNalmnlzxsxqy3SKbHtIBt1y2SRZgx8UQnTlSJLfDdZewKpOdjFS56xIxZ52CWgKDr09MXZ/ARx7QskhtPBAASr3jdloLsOcfyzz8q6LqHzZiNsFaew+O7OhbJHDpU9fbuGRB0NGtHF7xyi5xAIkiqMybLvlGg3sAlpRVbPgZizHo6YOmznfrZiySSCGF+D4GX7B9Lo5VTC10LN5cpqtgUkgsCanDBljHrFcwmktRQPL3cYNYiuYEiCWA/ESpwO7qiE5k+6Lj04M6d283XnieS09M3xwFcy7p/OFIyZn2428XFdnTOJHMd1pDHMml0ZWsZSJ9zNJaxDptB0TyAC50a0Rqz/i6XEHBlenrbuDPJ/Kf9IHjM67ZULKey9bG1yqWvMcasg9+FcB4431EXLRdRJCMACjrkdVuOdZe12zn1wlYrnXkBYTXGrBJS5zrZ5oogkgSA7dtfGoBw0JWtpYhOqfSi5YuPRazLiWqTcFZShCtcjVkX30vpdEdH9EWZKKBxCMSg/WIZRDLt4NGluRsvKpKaDxchjHkYjVnzYDZExbkFhrdewE4tkhslkiHgBMkKsq1Xr+HiGl/WwePa9PR07QVFkvfu3ZwEcCqrcHUBlzFrGcyC1zeH+lWLZCHe6eL1WE4ly2GBzQKc5EXXq6C3PYLGrEswe2VycvIeOrAdXZFEMt1mc2VrqWh5zvHCuwIM4fMr/VpjzAvYGhYvRO/YOpCQ+zkCIjC6Gb5ouSQJZNrBIyHeWcHOgACgAbwfY3wIF+8Ys7YGK5zu9DEogkiiWn00AnDUFy2XxvQmHoXYrGx9keeKAoBtXbpC8jrceceYNdMGCQDjWYtkAURSiodJbofb0RVeHdMOHrz5cHLfxAoz0TA+Pn5fwjt88UzUGLM8OyOgR5HJNXS4nRVin5kJX6Hb0ZXF+LIOHm8tYGXFAM2zW//Zw2nMGgaz0vnZqZ6ObwOZd5HMJkZf5nVbHlo6eISVrokY9FlJDbixhDFr5Hd5upPb0RVBJLOiHQSI+7xuy6GPqQXyndUacIhbPhB0HemDSe8wGNP2YBYrrkC3SK4j27e/1C9gr9vRlSI6DZIajMmZxyPWF/4+rNWuTgP8UrYN7+eSxrQ5mKXCaQ9F/jNJJMnCHhLD9oNlEEkC0k2gcnkVIrm4bgn8lofVmDUJZusx0dlV2qlFcj1EUoEHyLAJbkdXeOMjAZGXarWrtVXOpbK18R8l1fFiXXuMMc+3sDubk3jVA1GE7UvpdUczpTK+M2g+a175nKbnJTfxfUAXMr31c0lj2hLMEiLGb98+Pmnfm2+RzI4L8LjXbXkg23LtjgCEsbGxBwJ+288ljWmz34W+APx6He5qlVuRXGxHJ+AVLb1mCrzWJCCK59q4RsCoX4fXhzHtNVbyi7ar/Isk+vvnh0iMwO3oyhCdEor3FXj+8Yh1tRFv+LWoWHPEa0xbg9mzHooCiKS0MAqwz9NUBpEkQI5t7+aVNolkBMBabfwyhc/4fklj2hPMSvF+DAuX22SnFsk1nbGQHGHq/RrOJIttfEwb0F0YGxt7iPbdTZeuX+pXPMTGtEEkSZC8uSWE6xbJIohkxAmv2/JA4FRmdKFtRg1AjeTXfBTEmDYEswAgnZ+YmJhFB1+0XASRjABA4lWv2xJZoPBOu78lAMzsGXhHwHvecjWmLeHs1SIkUZ0skgSggYGBXkGHs3Z03motsDYiu2i5QV5ci++NU6fmCfxCq3AaY1bke4GAz3oo8i+SqHPTEYJ7Mp9nkSy+Vt6tAFdadwraSQPx3/tWEGNWpweSGhF430NRAJGkGqMkK3A7uhJkkoTA63fvdo+vwfePADA7vfUtAKdA3wpizMrsFAA01XgU1yyYtUi2c8Yijz4+eaaoxkcClE4DVx6h/ecZ0y1XXHkExE/Ra8aYFdopAfHqgwd7Jz0c+RbJdH+ViyJpymCBIbzfulOwFmsmgP9aio9S0bRQGvPCmSRxBnhrAW7OkVuRbG6VEcKhNXSqZn3nFGzg1Br+jAiA09O33xfwGZKCt4qMeXGllE7Z7+Y/k0RPz66dAvbLcUwZotOgGOfJuJqLlpe7liPEn8kM3EZuzAsGsyAueSjyn0kiBOxruWjZzq7QIkkIGG80KjfWWCQFAAtJ/WcV4wS8XWTMiwWzio8YK6fW2E4tku0QSSbxdZJpZmCRLLTxkQDJK/fu3Zxe458VAYSHk5M3Rf6SGwsY82LBLMSrW7fqrEUy3yKZzo54zBNVKq5g9RctLzvISsCfhCT4zKQxyw5mAVwcGxt7ALejy7VIZu3odMRTUyobfLtVxNZ6/UxP9/ynCHyRPjNpzAuEmDqX5+TJItmMXkZGtkI47IuWy7O+IuKpdfp52ZnJ83OM+uctrxljPtr3AsB7Hor8iyS2zy7sFvCyL1oufvoIgDHGB6ijXRctL/fnIoTkU1Kcgs9MGvNcHZAkRJ7zUBRAJFGpHCLDtqaT9RQVWCRJELi6dWtycx1FMgII09NjVyH+jAt4jHl+UCnpAaAr62inFsmVimQATmYPke3YCm582cGri+Pj4/exvsUAqTIG/Lgkdw8x5nnBLHl++/ZNYxbJfItkKoqKb3paShWmnt6AtdYAwHtT458T8GkX8BjzvGAW71y/fv2hA8r8imTTiSUijrRmA6bgkGc3cG1HRv2Ii8CMeW4w63Z0BcgksW3b8A6Ku3zRchlsLr1oOah+aoPeQwTAWu32L0Lxc1lzioanxpgPJSgAcNFDkf9MEpUtYQ+IIWf7pdHK6bkQL7YI53oLdQAwD/JHHSUb83QbkTQXpNMbZKcWyRcRSTXiIV+0XA7jIwmJlx9OTd3aQONLs8nu8NMxxvf8bNKYJ0WSkHC7Xl/XCnSL5MqnTG5HV54IFSROI93i3KhigDSbHBt7APD/gNttGfNEMAsQGpudHZuy7823SDY7B7ziKSmRBebjbroIgFT3v5R0EUuN840xAEScwlJvZZNDkcy2wEY3izzmop1SQAGgwpmcBGChVrs6Lejv02vLmMdFQHwrB8GsRfI5Iolq9eFLEPb7DsniB6YAAqQ6wEutOwUbnU12V/QTivqAziaNaRbtQMIpD0cBRBLgKIkeeE+8BHkkIehmjLycE5EUgDAxMTEbwb/tCTImtVQJM1K8mhM7tUg+J+c/3NJn05lkcYnZ5F2+d+/mZI6MLwLgvZ09P6MYP+9s0nR8JkkC0NWZ/q3XLZJFEEngVU9HiUJU8P3sj0lunAIQcP78XAR/QJIF0nS0SDI11LO4cuURXPmda5GMWVhz3NNRpjBV7+TwbTUAhHt3x39B0C+6C4+xoeJCDhMmi+RjCQeganW0D8IRpaWtnqyCrylJYOTp3Ca5ABDCD6TXAzmCNh1JmkgGfuChyL9IQpo7RGLY01GCuDQ9/lEDlNdigAaAZGby1ucB/Z9+Nmk61E6DpAU04ts5tVOLZKtIhhCPkdwEF+0U3/hIUBrL+d10AsCFJP7dGHUjswMLpekgkSQk3ZLmXNmac5FsctATVQ7jy4oBzmV30+V1KzMCCA/u3Bkj9b9kPV2N6RhIAOSVmZmZaY9GvkVSqWflIU9FqXgvZ0HYM4WyNr3zn0fFT7uIx3RWJgkAOoOl23KcoORQJBcvWoZwqOU1U+AAFQBiMTp4ZE7h1Dxj8t9LMc+ZrzFrYKw6Y7+b/0wS27e/1Cdgb1bZ6skq+HqS1EDA+ceFKNfZZFKrjb0F4YddxGM6KZileNZDkW+RDABAzu1vqWy1SBYXAQSEO1vmkJeercsVyrCpS38rSu+QTCyUptx2iiDFOUlXCmSnnZtJkpVX7JjKYXxp+Yuu3r5/e7JgTgMTExOzoP6qpHr2mh2HKW8wC16u1SpnLZIFEEkEvemJKk2ECgAXAdRRrGKACCCZmbr9KxL+kYM2U/ZgVsBpYOwBXLSTa5GM2ZS5srVERKrZaadoW+cRQOhK6j8Yo962UJpyS6XOFdROO0YkCUDDw8PbAB2QJ6sMUAJC5JeKnAlPTk7eU9CflzT3RIZsTHmMNeS2baRFsjV6ub/AvQL2wJWthY9L07UU50JxKluflU0m96Zu/46EH3C1qymhnSaSGkHxjIejACJJYT8ZtmaTZ5EstPERAsaAhaK3uYoAwszd8b+vGH8x23Z1kwFTJnOdfvQoXmxZ7yaHIpn98MarWUMwT1TBrY5Mz11NT0/XUOxD+c333Qhc+HMx6jrSOzG9Rk3xg9m0aufWw4f9kx6OfItk6ogUXvcUlAguFgMU/bqzCCCZnp6+KvJPI63WLXJ2bEwazAKQ8BZwfg6ubM2tSKbt6L4GFREnW14zRbdAsUzPORoAknvTt35J0g/6+aQpTzqJd+x38y+SGDw1uJPAsNvRlWMdSYLYOF+yz5Wen7x7/O9E6Wf9fNIU304BEOc9FPkWSQDAXEz2ANjhKShDYJpetBxi8kHLa2X5bAJ+vR4X+GcU43s+P2kKbaeKDyN5oWR2Ws5MElGHSFbgi5YLb3wkAelarbZ9rITGFwEks7O3JqD4JyXV4EuaTRFFkgTJsU2Yv26RLEAmCemoJ6o0ESpAni9xMUADQFKr3fmCGvjTaeLstWsKFsymSnllenp6xolJvkWy+RDyuIe/PHDpouWyGl8DQDIzM/7Tgv5HF/KYYhKvwhct51oks4uW3+wSeazkTrWD9BEQ9EEneBgAycz0+N+V4j9xIY8poLH+lkch/yKJ3t6roxAOurK18GR306mhpWKAsn/eCCDUpm//xSj9XCaUdS8Fk/N1m0iKEXjXw1EAkWQXR0n0wO3oymKDd7tQudFikGV3OABQZ+z+U4rxc1kBmjNKk387Zde1DrHTwopkOjsRh5n2o/MznYJbXTaPl6ambox3kPGl2WTt6vR86PpWSV/y1qvJu50KvDI1Vb1tkSyASBI44aEvU1bFMwAW0FnFABFA8nDqxnVEfaukcxZKk2c7pXQOODUPF+3kWiQjAEh4xUNfKjq1zVV2NOT2RSp+h6SrbjZgcgt5ukPttDAiSQDq7++vgjggebLKsH4EIAqnOngMGgCSu3cnvqTAb5d0x8dDTC6JuOxByL9IQqrsI7h76bikKShp0VWMjxQ6vs1VA0BlZvLW5xoK3ypp0kJpcmSniaR5IPlih9tpMUSyAbzhdnQlMT4SIK9vwvwNGx/qAJLZu2O/0VDjW6XYzCj9jNJssEgSgm6E8PCi7TTfIpn+QIZDnqhyGF92s/KVqampZpurTp/TRiqUdz4diT+kqGsu5jEbbqdpKnI5uxDdvjfHIpldtKxDHvby0NKOLng0loTy3tTt34Hit0i6YKE0G26n4jnbab5FMmtHhwTAgZbXTPED1VOez6cKZaVWm/hirDe+UTG+b6E0OQlmbac5ziSxdXBwEMA+t6MrvjIiLQYAFU4/tlNgmtQBJPfu3TmXhK5vkOLn3cLObISPl4AY4hkPRf4zSSQN7gO508NeGq28E0LiYoCPziiTqakb1+vz/GYp/kJLCzuPl1mPYJZSfBRZuWo7LYBIhoaOt1T8OZMssPFlba6uTk3duGXje65Qhvv3x2/Xpnu/PSr+WJZRymNm1sNOAVyY3QSLZM5FMvtp/LiHvDQRKihdQLp96DZXH01Mx+j83Mz07f9G0v+aBYvNZ/XGrJ2dAu9jbOyB7TTfIpm2owOPeshLBHm2dafAPNcGCCDUpse/X9CfAvAAPktp1nrhuR1d7kWSADQ4ONhD4WV5skohjwAQpdMeiheO7AUgqU2N/zgi/qAUL7ny1aylnSbSOQ9F/kUSc3PYJeAluLK1DI4+SGoE6b2W18zyxy87IjL+nxj5dVD8tZbG6B5L0047rcfYcDBbBJFEkhxioC9aLoXxEZBuSt0uBlg5dQBJrTZ+acvm5JsV9U+x9JzSWaVpj+sVbje2LFa2+vl3TkUy/UGMR+mJKoVIkoCIizMz16cskquiASCMjY09qN0d/3NIn1POePvVtM9ONX5/fPyOh6MAIhmF1zzcJYpRxQ+yPyYejdWZBpoFPVPjP46k8bWS3mrZfnVQaVYkklku+S4Wq6sdzOZRJJtbR5uIRZH0VmspTFDu4NFehxYBJLU7d94KmP86ST+aHhNx9atZVQj2tv1uATLJrVt37gCw3+3oyrFmBCCGcNZD0XYaAJLp6elabXr8L8QYvxPSDRf1mBXZqQQFfeChyH8miUqlsgdgn4e7FBkPEeN9Bbod3doJJQGEmbu3fwLSV0v4Bbqox7ygnUp6EJm4uK4IIolEB1uiYWeSRTY+EgCvzk5uumzjW1Mnl26/1m5frE3f+hYh/ncC7rUU9XjczUfaKcHrW5LGNdtpvkWyOTvHPVHlMD4CEHUeuPIIvmh5PbLKAAC1qdv/iDF+dZR+NRNKZ5XmI+0UwPmJiYlZ22m+RVIAECS3oyvTohFOr2eQ1eE0q1uTWm3iizPT438AUX8J0CQZXAFrng110Xaab5FsNm+uiDzmdnTlMLs0vQnveijWNzNoySobd++O/3AjJJ+E4qdAhpb+r84WzJKfJd/2UORfJNHbOzgKYb/b0ZXCUQdJDbBxoXWnwKxrVkkAyezk2Om70+PfJumPIuqct2DNE3ZaRyP5gu20ACKJJDlMshduR1cWG5yus+GKuXxklZyZHv9XsZF8Isb49wE8bLmr0luwHbs+CEm3YoSLdnIukk32p/d+2miLbnzZRcs3Hk5N3fZw5CKrFIDk3r2bkzN3b/8PiOF3Q/pZgGy53Nx213F2ChC8eu/ezWkPRwFEkojHPMylyWDSC1yBebjNVV5onqtMarWxt+5Oj38rYuPbJH0uzSr9vLIzlVJn4XZ0uRfJ5kXLJz3MJTI+LXbw8NZ5vgKYxS3YWm3iU329m786q4K98MTzSjvMjoBnbKf5FkkC0MDAQC+gg65sLYfVAQCF9zwUuWVxC/bKlSuP7t4d/+FYT74yxvg/A5iwWHaQnTL6ouUCiCSkyijB3a5sLUWmEhTjw0YSzrS8ZvLJ4hZs9rzyBxHxFRH6B9LiVVwWy5LaaYx6xIjzttMCiGQDPAmyC25HVwLjI0COdXPhuo2vMA6z5Xnl+OWZqfG/FuvhK6X4wwJqWTMCi2WZ5pwEoat3t1TO2U7zLZKpUkpv0BNVCuMjAQmXJicn79n4CimWAUAyOzt2ujZ9+y/FEL5KavwIgMmswKcplq6GLbKdpinKWYyNPYDb0eVaJJsTM+ohLhXNNle+aLl4xMfEcnLsdG369veqEb8yxvi/LV3JxQC3uis0BM+vRxJkkVzNHGU3GIA42PKaKb6f/ZLHoFxiOTMzcWHm7u2/vlBpfLmEvwroHMmQnbNsZqHORgq1deA7JIuQSWLr4OAgwL2+aLkc60QCKJ72UJRTLB/cuTNWm771DxMufBwxfmdU/DTSrgStzy2dXeZZG4FEkqjF4jqT40wSlUbYC2DQQ1wK46OgGkD3bC2vWBJAMjU1NXP37u2fmJm+/TVi/AOS/uViRayzyyIYa40MF1vm1uRQJAMAhMjj2ZaNK1sLbndM+wpertW2j1kkSx0MLYolAMxMTfxybXr8T6hR+bikH0LUqbTjnbPLHNvp1enprgkPR75FUmkIE0/aoZbGeQLABeD8HNzmqlPEEplYhnv3bpyrTY//zc3d+Ao04h+Oij8PYfYp2aUFc+Pt9O3sQnTbaZuorMH3TA2F/DIPb3kg5DZXnUejJZjm+Pj4fQA/B+DnBgZ2najH+IdB/hECr5JM0vIDNbv+BK+VjbBTnLKd5juTJACNjIxsJfSy29GViEi3uerg2cfjW7Gcmrp1aubu7R8a2rH9y0X9fkn/RIiXssrY5rnL6AxzPfURAHnJQ5HvTJIAdP9+/SWEMEK4srXgNCvm6jHIla1GT2aX58+fnwPwKwB+pVqt9sew+fcT+iYJXxdC2A0g60qp5h2XbPll2jcvQdI8YuJ2dAUQSaCCAxS3Z4ZhYyi+DU7HrsVGAjY+g5bskJlgolarTQO1fwXgX20bHh5K5uPXNYRvBfEVRNhLorkli5bM1ILZFpEkpTgeG/JFy0UQSYInszZmaVMBU1hHSDJRxIX7t8fv2PjMc7LLpmDq/vj47fvATwL4yZ6ekZ2VSuN3ifxmQX+A4GhWIYvsHPWTX29ecA5Sf8trs7NjU7bTfItkc2PlVTo2LJEX1CksHTz38yXzQoI5Ozt2B8C/BfBvq9VqH7D5DQV9LYSvB/UxMmxudR5PfA9nmsvNUIgLWLpo2XaaQ5FsnptKKJzwsi6T8fmiZdMWwUStVrsL1H4NwK8B+P7+/uFXIvSVEH43gE8COLiUZS5Kp0VzGUTh87bT/Iuk+vv7X4rAkWwbxVsnxabZju6sh8K0WzABNKanx98D8B6A/2twcLBnYUFfFln5PZDeBPQawX2LormknM1jJhbNpaIdBOmUl1r+RRJ1VF4OYJ8jmlIYH6X4qE63ozNrJpjNX5qYmJgF8OnsF6rVal8Im05GhU8K+i8IHoU0yhC6F7/ZUroZOzjbpKQH6qpctZ3mWyQBAIl4AIGUFJ1JFtyZkSRwdXOoX71v4zNrI5h6ItBu+oyYbs3iN7NfGBwc7KnXub/e0JuB+ISIr4BwkMT2Zrb5DOEss3g27fRGl+bcNrIIIinysC9aLofxEYCEC9lFy77A1axnlvmkaDYzzXezX/838GZXtXrtZQUcREMnFfgxQK8Q3AdwgFyqrG/Zqn2aeKLAAmo7LZBIKgvjjsKlraWBRLMdXXjCgRmzEaLZImZvLdRquIj0MvBfaa7T/v6RPQ02jko4APEwiUMQjgt6meSW1qzzce38SAHFU/6cn4GS7TTvItlsQdUloplJWilL4aX0vkfB5Eg09WzRTEVuenrsKoCrrV84MjKy9d489ib1xu4G9UoQDihgP4FdAoYI7AJCd2v2+UQG2vpSfIYP3DhBZTyXZxG3SGZs2fHyIOP8qC9aLgWJJAXfcm6KI5pPE04AiGNjYw8AnM5+/WrL34VqdW+1HuZ2B2BvQDwCcYeAE4B2EhgCMCChh+Tm7Pq/5FlvpuVfT75HrdHnh6Qo8gvNz+plkU+RDAAaXZo7CXAAS+XZprjOh4CmgMo1G58puHA+UzwBxFrt6jSAaaRHUX6x9YuGh4e3NRqN3jmpF+jqRb3xMhn2RKgKYj+FYYCJiG2U+gRWSW2BsB1kd1ZUs4a+kFBs3FY9OdcqnCanmSQijzKtbG3A7egK7WhIMgo3pqf7bwFjHhFTZvF8UkSb/2/Mrge7jyUj+NyzfsDIyMjWe/ewddOmuc1RyQ4o9DWAbYS2E9pOYZvIbkndJDdJcQvJTSB2Say0vI9AqPWqMSntzyoAdUI3Ac5IegggJoxfrM3edtvIIogkqSNOIEvjUADgMnBqHq6YM+Vf63pmqvZ0MdUT4qtsS/dB9vp1D61FEk9sWwDicWtkeSDwTvZHV8wZi+hzzeWZwrrcn/ECpvkhbJ85FkkC0MDAQG9dOpie2rFUFl8fAQGubDXmxYXOuy4loh0dcVKHqsoogZfgi5bLYOxB0gJjPG2jN8ZYJNsgkjHqKBm6sXT7uCmsSBKCxoD5yxZJY4xFsi3fiW/aoZZDJLOGSVdqtVrNw2GMsUiuOvMABB72cJYqnzyXzW3iwMcYY5FcGc12dAmhl1teMwWHDO60Y4zpeNpyBGTbtqGdEPfKIlmKwEkSxPiOh8IY40yyDV+fdHMUxKB35QpPdtEyZpHgYstrxhhjkVy5a9UhpNfPuLK16CJJgtT1me7uGxZJY4xFsg0QeMUXLZdDJLN5PIfr1x/C7eiMMRbJVZG1o8PrHsoyKSXPtjOIMsaYThRJAtDw8PA2kMeye0m91VoCKJ32KBhjzOpFEg8fxhFpsWjHIllsEklA5EUPhTHGtEEkSe4juR2+aLnoZM8eNRXC/PnsNV+0bIyxSK4GEiezNmZ2qAUXSZIQeHV6+rWbHg5jjGmDSEbwpIexPJkkpTPAr9ezteHKVmOMRXKFNACAwKvNpNLDWQqlfMfzaYwxqxNJAsDOnTtHQB2Q840ykD5jFk55KIwxZnUiGQCgXq8cBjiU7cr5TF2hE0gExfgoBFxoec0YYyySK6UB7GVateOincKLJCFgIsbN1y2SxhjTBpEMahyyQy0HJBCIC7Xa1Rr8PNIYY1Ylkll/HR73EJYlkwSieC7bFXBlqzHGrFAkFy9aFnm45TVTfKV8z6NgjDGrF0lsGdg9Qmif5HZ0ZVgHkhCCXNlqjDHtEMlNjfphgH0ewjIkkKCEe2j4omVjjFmtSKYkeoNpaWvDmWSxRTKdRt3YujW5ZZE0xph2iKQWn0ea4meSIHhlbGzsAXzRsjHGrEokmxctH/DwlUop31914GSMMR0ukgSgwcHBHhAHfNFyKWi2o3vXQ2GMMasXSTx8WNkj6WVftFyGBBJBUiMmOu3hMMaYNohkktRPhBA2I916tUgWXSmlcc0H92w1xphVimTqRZm8YodaCiJJELw8O3vrTvM1D4sxxqxMJLOnkPHjHroSQZzP5tZFO8YYs0KRTNvRHTrUDXC05TVTcAR84Pk0xpjViyT6Jx8MEdrtdnTlmH8BiNFFO8YY0xaRlOJ+gAMeujIkkKBifMCueKrlNWOMMSsQydSLMh5xO7qSiCQJkjc2kzctksYY0waRJHjSw1YOkUy3BnBhYmJiFm5HZ4wxqxLJCIARes3DViql/GClAZMxxlgkmwkkoG3bhgcJnsyKduxUyyGTZz0GxhizepFEpdLYA2CHh60ccy8BaOCCh8IYY9ogkkjCKMkK3I6u8OkjAEJxrpFwrOU1Y4wxKxDJ1IuKR+1QyyKSBMjrm0P9iufUGGPaIJIEjnnIyiGSTGtZL05OTt6DK1uNMWZVItlA2p3loIesTErpi5aNMWa1IkkA6BkZGYBw0JWtpSC9aJl4z0NhjDGrE8kAAJWHOkFiuNXJmuKKpKTIGHz8wxhjVimSGY19JAN832DRSStboekQ5i61vGaMMeYJKsv2rAwjTJ2pHWp+xG45r7PldwFokEyi9P7U1FSzZ6sDH2OMWZVICoHM7pT8cAbq7df1EUUtZYLP3AUgyBap1BMZJJtz/k+zuUyQFmYZY4xZgUimF0dKn5UwR7I7K955VgajZWY8T3fwa/P/buT3XE2G2PrnAGT3rwCQJEgPBdZBiFADQEPAQ0bdF7lAoEfCEIme7LPVhXgN0j+ZmZ74qew1C6QxxrRDFLZXh787EP8tgH0CqqQ2ZZnJUlaTpZtrohxaqfauWKTW5Qc+MQ98MilcFEXonIDfJvFFRl5oME6GWJkD6o16YIOhsdAVNz1YWNDDECqNSuXB1gVU9gToJYndJCYqbJyanJy86aVvjDFrkDmNjIxsvX+//hK6kn7W1ROJHhLbFLGFQZtIbFXEFoTQRSkBVJHYLWILoc0EN0HqEpkASAAlFCoguwR1AUwgJIQCgERpG7yEUgVkRVAFQAIxIZCACs0sC+lZzgAhAApMPx/Bxb9v/YWn/Peyhobtyjn1pPIu/teCgAcEJgVdgfB5gZ/urjTeunPnzlgbfrILsIwxZg1Eci2da/M5W1gSrj1hcHAuaTQaodFoJI3G1mTLlnql0WgkUncSYwyAQowxATYFdcUgKXRJiVRJpJigoiApERQghURKgEoARCVKIAQhCZCSkCiBQgIgSLEiIQEUoJCEBAFSkopwCIASBiVQqABKJCVL48mYboGmzxDTr1HIMu1IsA7GuiIXSC2AXIhRCyTng/RI4j0yTs1XdPvBnTsTAOpPGaflZr2tQUDrc01jjDHtziSfkXnxGQ76o5z3cv5/sxScNIumPF7GGJNjkcyTWOdpDNpZoKRn/G6MMcYYY4wxxhhjjDHGGGOMMcYYY4wxxhhjjDHGGGOMMcYYY4wxxjyX/x+i5+k9cWHDzQAAAABJRU5ErkJggg==" preserveAspectRatio="xMidYMid meet"/>
+        </g>
+
+        <!-- NODE: HIỂU MÌNH — Giáo dục (gold) -->
+        <g class="node" data-domain="edu" tabindex="0" role="button" aria-label="Giáo dục — Hiểu mình">
+          <circle class="node-hit" cx="250" cy="172" r="78"/>
+          <circle cx="250" cy="172" r="46" fill="#E5A92B" opacity=".18" filter="url(#soft)"/>
+          <circle class="node-core" cx="250" cy="172" r="30" fill="#E5A92B" stroke="rgba(255,255,255,.65)" stroke-width="1.5"/>
+          <text class="node-num" x="250" y="178">01</text>
+          <text class="node-label" x="250" y="100" data-en="Understand" data-vi="Hiểu mình">Understand</text>
+          <text class="node-sub" x="250" y="120" fill="#E5A92B" data-en="Education" data-vi="Giáo dục">Education</text>
+        </g>
+
+        <!-- NODE: PHÁT TRIỂN — Nội dung (red) -->
+        <g class="node" data-domain="content" tabindex="0" role="button" aria-label="Nội dung & truyền thông — Phát triển">
+          <circle class="node-hit" cx="630" cy="172" r="78"/>
+          <circle cx="630" cy="172" r="46" fill="#E23744" opacity=".18" filter="url(#soft)"/>
+          <circle class="node-core" cx="630" cy="172" r="30" fill="#E23744" stroke="rgba(255,255,255,.55)" stroke-width="1.5"/>
+          <text class="node-num" x="630" y="178" fill="#fff">02</text>
+          <text class="node-label" x="630" y="100" data-en="Grow" data-vi="Phát triển">Grow</text>
+          <text class="node-sub" x="630" y="120" fill="#E23744" data-en="Content &amp; Media" data-vi="Nội dung &amp; Truyền thông">Content &amp; Media</text>
+        </g>
+
+        <!-- NODE: KẾT NỐI — Không gian & cộng đồng (green) -->
+        <g class="node" data-domain="space" tabindex="0" role="button" aria-label="Không gian và cộng đồng — Kết nối">
+          <circle class="node-hit" cx="662" cy="552" r="78"/>
+          <circle cx="662" cy="552" r="46" fill="#46A06B" opacity=".18" filter="url(#soft)"/>
+          <circle class="node-core" cx="662" cy="552" r="30" fill="#46A06B" stroke="rgba(255,255,255,.55)" stroke-width="1.5"/>
+          <text class="node-num" x="662" y="558" fill="#fff">03</text>
+          <text class="node-label" x="662" y="618" data-en="Connect" data-vi="Kết nối">Connect</text>
+          <text class="node-sub" x="662" y="638" fill="#46A06B" data-en="Spaces &amp; Community" data-vi="Không gian &amp; Cộng đồng">Spaces &amp; Community</text>
+        </g>
+
+        <!-- NODE: CHO ĐI — Vì cộng đồng (rose) -->
+        <g class="node" data-domain="care" tabindex="0" role="button" aria-label="Vì cộng đồng — Cho đi">
+          <circle class="node-hit" cx="218" cy="552" r="78"/>
+          <circle cx="218" cy="552" r="46" fill="#E8607D" opacity=".18" filter="url(#soft)"/>
+          <circle class="node-core" cx="218" cy="552" r="30" fill="#E8607D" stroke="rgba(255,255,255,.55)" stroke-width="1.5"/>
+          <text class="node-num" x="218" y="558" fill="#fff">04</text>
+          <text class="node-label" x="218" y="618" data-en="Give back" data-vi="Cho đi">Give back</text>
+          <text class="node-sub" x="218" y="638" fill="#E8607D" data-en="Community" data-vi="Vì cộng đồng">Community</text>
+        </g>
+
+        <!-- NODE: CÔNG NGHỆ — nền tảng (orange) -->
+        <g class="node" data-domain="tech" tabindex="0" role="button" aria-label="Công nghệ — nền tảng đỡ cả hệ">
+          <circle class="node-hit" cx="440" cy="668" r="70"/>
+          <circle cx="440" cy="668" r="40" fill="#F2752B" opacity=".18" filter="url(#soft)"/>
+          <circle class="node-core" cx="440" cy="668" r="26" fill="#F2752B" stroke="rgba(255,255,255,.55)" stroke-width="1.5"/>
+          <text class="node-sub" x="440" y="672" fill="#fff" style="text-transform:none;font-size:10px" font-weight="700" data-en="FOUNDATION" data-vi="NỀN TẢNG">FOUNDATION</text>
+          <text class="node-sub" x="440" y="712" fill="#F2752B" data-en="Technology" data-vi="Công nghệ">Technology</text>
+        </g>
+      </svg>
+      </div><!-- /.eco-orbital -->
+
+      <!-- mobile: conả đứng (phone) -->
+      <div class="eco-vertical">
+        <div class="ev-core">
+          <span class="ev-mark" aria-hidden="true"></span>
+          <div><b>NhiLe Holding</b><span data-en="Ecosystem core" data-vi="Lõi hệ sinh thái">Ecosystem core</span></div>
+        </div>
+        <div class="ev-rail">
+          <button class="node ev-row" data-domain="edu" style="--c:var(--edu)">
+            <span class="ev-num">01</span>
+            <span class="ev-txt"><b data-en="Understand yourself" data-vi="Hiểu mình">Understand yourself</b><small data-en="Education" data-vi="Giáo dục">Education</small></span>
+          </button>
+          <button class="node ev-row" data-domain="content" style="--c:var(--content)">
+            <span class="ev-num">02</span>
+            <span class="ev-txt"><b data-en="Grow" data-vi="Phát triển">Grow</b><small data-en="Content &amp; Media" data-vi="Nội dung &amp; Truyền thông">Content &amp; Media</small></span>
+          </button>
+          <button class="node ev-row" data-domain="space" style="--c:var(--space)">
+            <span class="ev-num">03</span>
+            <span class="ev-txt"><b data-en="Connect" data-vi="Kết nối">Connect</b><small data-en="Spaces &amp; Community" data-vi="Không gian &amp; Cộng đồng">Spaces &amp; Community</small></span>
+          </button>
+          <button class="node ev-row" data-domain="care" style="--c:var(--care)">
+            <span class="ev-num">04</span>
+            <span class="ev-txt"><b data-en="Give back" data-vi="Cho đi">Give back</b><small data-en="For the community" data-vi="Vì cộng đồng">For the community</small></span>
+          </button>
+          <button class="node ev-row ev-base" data-domain="tech" style="--c:var(--tech)">
+            <span class="ev-num">＋</span>
+            <span class="ev-txt"><b data-en="Technology" data-vi="Công nghệ">Technology</b><small data-en="Foundation for the whole system" data-vi="Nền tảng đỡ cả hệ">Foundation for the whole system</small></span>
+          </button>
+        </div>
+      </div>
+      <!-- panel hé lộ thương hiệu con -->
+      <div class="eco-panel" id="ecoPanel" aria-live="polite">
+        <div class="ph">
+          <span class="swatch" id="panelSwatch" style="background:var(--edu)"></span>
+          <span class="stage" id="panelStage">01 · Understand yourself</span>
+        </div>
+        <h3 id="panelTitle" class="ph" style="display:block;margin:0 0 6px">Education</h3>
+        <p class="pdesc" id="panelDesc">Where the journey of self-understanding begins.</p>
+        <div class="brand-chips" id="panelChips"></div>
+      </div>
+      <div class="eco-hint" data-en="↑ Tap or hover over a territory to see the brands inside" data-vi="↑ Chạm hoặc rê chuột vào một vùng để xem các thương hiệu bên trong">↑ Tap or hover over a territory to see the brands inside</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============ DOMAIN DETAIL GRID ============ -->
+<section class="section" id="domains" style="padding-top:0">
+  <div class="wrap">
+    <div class="sec-head reveal">
+      <span class="eyebrow" data-en="A closer look" data-vi="Nhìn gần hơn">A closer look</span>
+      <h2 data-en="Five territories, nine brands" data-vi="Năm vùng đất, chín thương hiệu">Five territories, nine brands</h2>
+      <p data-html data-en="The map above shows the shape of the ecosystem at a glance. Below is each territory in full — and every brand that lives within it." data-vi="Sơ đồ phía trên cho bạn hình dung tổng thể trong một cái nhìn. Dưới đây là từng vùng đất một cách đầy đủ — cùng mọi thương hiệu bên trong.">The map above shows the shape of the ecosystem at a glance. Below is each territory in full — and every brand that lives within it.</p>
+    </div>
+    <div class="domain-grid">
+      <article class="card reveal" style="--c:var(--edu)">
+        <div class="stage-tag"><b>01</b> · <span data-en="Understand yourself" data-vi="Hiểu mình">Understand yourself</span></div>
+        <h3 data-en="Education" data-vi="Giáo dục">Education</h3>
+        <p data-en="Where the journey of self-understanding begins." data-vi="Nơi mỗi hành trình hiểu mình bắt đầu.">Where the journey of self-understanding begins.</p>
+        <div class="brands"><a href="https://nedu.vn/" target="_blank" rel="noopener">N Education — Nedu</a></div>
+      </article>
+      <article class="card reveal d1" style="--c:var(--content)">
+        <div class="stage-tag"><b>02</b> · <span data-en="Grow" data-vi="Phát triển">Grow</span></div>
+        <h3 data-en="Content &amp; Media" data-vi="Nội dung &amp; Truyền thông">Content &amp; Media</h3>
+        <p data-en="Inspiration that reaches people every day." data-vi="Lan toả cảm hứng đến mọi người mỗi ngày.">Inspiration that reaches people every day.</p>
+        <div class="brands"><a href="https://www.youtube.com/@NHILE_SG" target="_blank" rel="noopener">NhiLe — YouTube</a><a href="https://mkt.nhi.sg/" target="_blank" rel="noopener">N Digital Marketing</a></div>
+      </article>
+      <article class="card reveal d2" style="--c:var(--space)">
+        <div class="stage-tag"><b>03</b> · <span data-en="Connect" data-vi="Kết nối">Connect</span></div>
+        <h3 data-en="Spaces, Experiences &amp; Community" data-vi="Không gian, Trải nghiệm &amp; Cộng đồng">Spaces, Experiences &amp; Community</h3>
+        <p data-en="Where people meet, experience, and belong." data-vi="Nơi con người gặp gỡ, trải nghiệm và thuộc về.">Where people meet, experience, and belong.</p>
+        <div class="brands"><a href="https://sw.nhi.sg/" target="_blank" rel="noopener">S&amp;W — Share and Work</a><a href="https://tih.nhi.sg/" target="_blank" rel="noopener">This is home</a><a href="https://bloom.nhi.sg/" target="_blank" rel="noopener">BLOOM Retreat</a><a href="https://hush.nhi.sg/" target="_blank" rel="noopener">HUSH Garden Cafe &amp; Workspace</a></div>
+      </article>
+      <article class="card reveal d1" style="--c:var(--care)">
+        <div class="stage-tag"><b>04</b> · <span data-en="Give back" data-vi="Cho đi">Give back</span></div>
+        <h3 data-en="For the community" data-vi="Vì cộng đồng">For the community</h3>
+        <p data-en="Giving back to make the journey whole." data-vi="Cho đi để hành trình trở nên trọn vẹn.">Giving back to make the journey whole.</p>
+        <div class="brands"><a href="https://www.nlf.sg/" target="_blank" rel="noopener">NhiLe Foundation</a></div>
+      </article>
+      <article class="card reveal d2" style="--c:var(--tech)">
+        <div class="stage-tag"><b>＋</b> · <span data-en="Foundation" data-vi="Nền tảng">Foundation</span></div>
+        <h3 data-en="Technology" data-vi="Công nghệ">Technology</h3>
+        <p data-en="The digital foundation that holds the whole ecosystem together." data-vi="Nền tảng số gắn kết toàn bộ hệ sinh thái.">The digital foundation that holds the whole ecosystem together.</p>
+        <div class="brands"><a href="https://familycloud.nhi.sg/" target="_blank" rel="noopener">Family Cloud</a></div>
+      </article>
+    </div>
+    <!-- Brands: 9 named across 5 territories (NHI'S HOUSE removed; space order S&W, this is home, BLOOM, HUSH). -->
+  </div>
+</section>
+
+<!-- ============ PROOF ============ -->
+<section class="section proof" id="proof">
+  <div class="wrap">
+    <div class="sec-head reveal">
+      <span class="eyebrow" data-en="Living proof" data-vi="Bằng chứng sống">Living proof</span>
+      <h2 data-en="Over 5,000 real stories — and counting" data-vi="Hơn 5.000 câu chuyện thật — và vẫn tiếp tục">Over 5,000 real stories — and counting</h2>
+      <p data-en="These are not numbers on a slide. They are learners who found clarity and a community that found one another — built steadily over eight years, entirely in public view." data-vi="Đây không phải những con số trên một trang trình bày. Đó là những học viên tìm thấy sự rõ ràng và một cộng đồng tìm thấy nhau — được xây dựng bền bỉ suốt tám năm, hoàn toàn công khai.">These are not numbers on a slide. They are learners who found clarity and a community that found one another — built steadily over eight years, entirely in public view.</p>
+    </div>
+    <div class="stat-row">
+      <div class="stat reveal"><div class="num" data-to="200" data-suffix-en="K+" data-suffix-vi="K+">200K+</div><div class="lbl" data-en="Subscribers" data-vi="Người theo dõi">Subscribers</div></div>
+      <div class="stat reveal d1"><div class="num" data-to="8" data-suffix-en=" yrs" data-suffix-vi=" năm">8 yrs</div><div class="lbl" data-en="Building in public" data-vi="Xây dựng công khai">Building in public</div></div>
+      <div class="stat reveal d2"><div class="num" data-to="130" data-suffix-en="+" data-suffix-vi="+">130+</div><div class="lbl" data-en="People on the team" data-vi="Thành viên trong đội ngũ">People on the team</div></div>
+      <div class="stat reveal d3"><div class="num" data-to="9" data-suffix-en="" data-suffix-vi="">9</div><div class="lbl" data-en="Brands across the ecosystem" data-vi="Thương hiệu trong hệ sinh thái">Brands across the ecosystem</div></div>
+    </div>
+    <div class="proof-foot reveal d2">
+      <div class="social">
+        <a class="s" href="https://www.facebook.com/nhilesg.anne" target="_blank" rel="noopener" aria-label="Facebook">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#1877F2" d="M24 12c0-6.6-5.4-12-12-12S0 5.4 0 12c0 6 4.4 11 10.1 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.6 4.5-4.6 1.3 0 2.7.2 2.7.2v2.9h-1.5c-1.5 0-1.9.9-1.9 1.8V12h3.3l-.5 3.5h-2.8v8.4C19.6 23 24 18 24 12z"/></svg>
+        </a>
+        <a class="s" href="https://www.youtube.com/@NHILE_SG" target="_blank" rel="noopener" aria-label="YouTube">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#FF0000" d="M23.5 6.2a3 3 0 0 0-2.1-2.1C19.5 3.6 12 3.6 12 3.6s-7.5 0-9.4.5A3 3 0 0 0 .5 6.2 31 31 0 0 0 0 12a31 31 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.1c1.9.5 9.4.5 9.4.5s7.5 0 9.4-.5a3 3 0 0 0 2.1-2.1A31 31 0 0 0 24 12a31 31 0 0 0-.5-5.8z"/><path fill="#fff" d="M9.6 15.6 15.8 12 9.6 8.4z"/></svg>
+        </a>
+        <a class="s" href="https://www.google.com/maps/place/Nhi+Le/@12.0866744,95.2353553,5z/data=!4m6!3m5!1s0x46e5d6c25fcc4373:0x6fdcf4bf1de01cd2!8m2!3d12.2711252!4d105.9102332!16s%2Fg%2F11rcg8m5fd?entry=tts" target="_blank" rel="noopener" aria-label="Google Maps">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="#4285F4" d="M23.5 12.3c0-.8-.1-1.6-.2-2.3H12v4.5h6.4a5.5 5.5 0 0 1-2.4 3.6v3h3.9c2.3-2.1 3.6-5.2 3.6-8.8z"/><path fill="#34A853" d="M12 24c3.2 0 6-1.1 8-3l-3.9-3a7.2 7.2 0 0 1-10.7-3.8H1.3v3a12 12 0 0 0 10.7 6.8z"/><path fill="#FBBC05" d="M5.3 14.3a7.1 7.1 0 0 1 0-4.6v-3H1.3a12 12 0 0 0 0 10.7z"/><path fill="#EA4335" d="M12 4.8c1.8 0 3.4.6 4.6 1.8l3.5-3.5A12 12 0 0 0 1.3 6.6l4 3.1A7.1 7.1 0 0 1 12 4.8z"/></svg>
+        </a>
+      </div>
+      <span class="sep"></span>
+      <span class="stars" aria-label="5 out of 5">
+        <svg viewBox="0 0 24 24"><path d="M12 2l2.9 6.3 6.9.7-5.1 4.7 1.4 6.8L12 17.8 5.9 21.2l1.4-6.8L2.2 9.7l6.9-.7z"/></svg>
+        <svg viewBox="0 0 24 24"><path d="M12 2l2.9 6.3 6.9.7-5.1 4.7 1.4 6.8L12 17.8 5.9 21.2l1.4-6.8L2.2 9.7l6.9-.7z"/></svg>
+        <svg viewBox="0 0 24 24"><path d="M12 2l2.9 6.3 6.9.7-5.1 4.7 1.4 6.8L12 17.8 5.9 21.2l1.4-6.8L2.2 9.7l6.9-.7z"/></svg>
+        <svg viewBox="0 0 24 24"><path d="M12 2l2.9 6.3 6.9.7-5.1 4.7 1.4 6.8L12 17.8 5.9 21.2l1.4-6.8L2.2 9.7l6.9-.7z"/></svg>
+        <svg viewBox="0 0 24 24"><path d="M12 2l2.9 6.3 6.9.7-5.1 4.7 1.4 6.8L12 17.8 5.9 21.2l1.4-6.8L2.2 9.7l6.9-.7z"/></svg>
+      </span>
+      <span class="sep"></span>
+      <span data-html data-en="Rated <b>5 out of 5</b> across Facebook, YouTube and Google" data-vi="Đánh giá <b>5 trên 5</b> trên Facebook, YouTube và Google">Rated <b>5 out of 5</b> across Facebook, YouTube and Google</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============ CTA ============ -->
+<section class="section" id="cta" style="padding-top:0">
+  <div class="cta-band reveal">
+    <span class="eyebrow" style="display:block;margin-bottom:18px" data-en="Partner with NhiLe" data-vi="Đồng hành cùng NhiLe">Partner with NhiLe</span>
+    <h2 data-en="Where would you like to begin on this journey?" data-vi="Bạn muốn bắt đầu từ đâu trên hành trình này?">Where would you like to begin on this journey?</h2>
+    <p data-en="Whether you want to learn, connect, or give back — there is always an open door in the NhiLe ecosystem." data-vi="Dù bạn muốn học, muốn kết nối, hay muốn cho đi — luôn có một cánh cửa trong hệ sinh thái NhiLe đang mở.">Whether you want to learn, connect, or give back — there is always an open door in the NhiLe ecosystem.</p>
+    <div class="hero-cta" style="margin-top:0">
+      <a class="btn btn-gold" href="#ecosystem" data-en="Explore the ecosystem" data-vi="Khám phá hệ sinh thái">Explore the ecosystem</a>
+      <a class="btn btn-ghost" href="#proof" data-en="Read the community story" data-vi="Đọc câu chuyện cộng đồng">Read the community story</a>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<!-- ============ FOOTER ============ -->
+<footer class="footer">
+  <div class="wrap">
+    <a class="brand" href="#top">
+      <span class="mark" aria-hidden="true"></span>
+      <span>NhiLe Holding<small data-en="Understand · Grow · Give back" data-vi="Hiểu mình · Phát triển · Cho đi">Understand · Grow · Give back</small></span>
+    </a>
+    <div class="foot-links">
+      <div class="fcol">
+        <h5 data-en="Ecosystem" data-vi="Hệ sinh thái">Ecosystem</h5>
+        <a href="#ecosystem" data-en="Education" data-vi="Giáo dục">Education</a>
+        <a href="#ecosystem" data-en="Content &amp; Media" data-vi="Nội dung &amp; Truyền thông">Content &amp; Media</a>
+        <a href="#ecosystem" data-en="Spaces &amp; Community" data-vi="Không gian &amp; Cộng đồng">Spaces &amp; Community</a>
+        <a href="#ecosystem" data-en="For the community" data-vi="Vì cộng đồng">For the community</a>
+        <a href="#ecosystem" data-en="Technology" data-vi="Công nghệ">Technology</a>
+      </div>
+      <div class="fcol">
+        <h5 data-en="Journey" data-vi="Hành trình">Journey</h5>
+        <a href="#journey" data-en="01 · Understand yourself" data-vi="01 · Hiểu mình">01 · Understand yourself</a>
+        <a href="#journey" data-en="02 · Grow" data-vi="02 · Phát triển">02 · Grow</a>
+        <a href="#journey" data-en="03 · Connect" data-vi="03 · Kết nối">03 · Connect</a>
+        <a href="#journey" data-en="04 · Give back" data-vi="04 · Cho đi">04 · Give back</a>
+      </div>
+      <div class="fcol" id="contact">
+        <h5 data-en="Contact" data-vi="Liên hệ">Contact</h5>
+        <a href="mailto:contact@nhi.sg">contact@nhi.sg</a>
+        <a href="https://maps.app.goo.gl/BUheceBhrwjbcRUV9" target="_blank" rel="noopener" data-en="View address on map" data-vi="Xem địa chỉ trên bản đồ">View address on map</a>
+        <a href="https://www.youtube.com/@NHILE_SG" target="_blank" rel="noopener" data-en="Story" data-vi="Câu chuyện">Story</a>
+      </div>
+    </div>
+    <div class="legal">
+      <span data-en="© 2026 NhiLe Holding · An ecosystem for human growth." data-vi="© 2026 NhiLe Holding · Một hệ sinh thái vì sự phát triển con người.">© 2026 NhiLe Holding · An ecosystem for human growth.</span>
+      <span data-en="NhiLe TEAM — 130+ people behind everything we build." data-vi="NhiLe TEAM — 130+ con người đứng sau mọi mảnh ghép.">NhiLe TEAM — 130+ people behind everything we build.</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+(function(){
+  "use strict";
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ---------- ngôn ngữ / language ---------- */
+  var L = 'en'; /* mặc định Tiếng Anh / default English */
+
+  /* ---------- dữ liệu domain (song ngữ) ---------- */
+  var DOMAINS = {
+    edu:    { color:'var(--edu)',
+              stage:{en:'01 · Understand yourself', vi:'01 · Hiểu mình'},
+              title:{en:'Education', vi:'Giáo dục'},
+              desc:{en:'Where the journey of self-understanding begins.', vi:'Nơi mỗi hành trình hiểu mình bắt đầu.'},
+              brands:[{name:'N Education — Nedu', url:'https://nedu.vn/', desc:{en:'An adult learning platform for self-discovery and personal growth.', vi:'Nền tảng học tập dành cho người trưởng thành — khám phá bản thân và phát triển.'}}] },
+    content:{ color:'var(--content)',
+              stage:{en:'02 · Grow', vi:'02 · Phát triển'},
+              title:{en:'Content & Media', vi:'Nội dung & Truyền thông'},
+              desc:{en:'Inspiration that reaches people every day.', vi:'Lan toả cảm hứng đến mọi người mỗi ngày.'},
+              brands:[
+                {name:'NhiLe — YouTube', url:'https://www.youtube.com/@NHILE_SG', desc:{en:'An inspirational channel on living and growth — 200K+ subscribers over eight years.', vi:'Kênh truyền cảm hứng sống và phát triển — hơn 200K người theo dõi trong tám năm.'}},
+                {name:'N Digital Marketing', url:'https://mkt.nhi.sg/', desc:{en:'In-house media and marketing for the entire ecosystem.', vi:'Bộ phận truyền thông và marketing nội bộ cho cả hệ sinh thái.'}}
+              ] },
+    space:  { color:'var(--space)',
+              stage:{en:'03 · Connect', vi:'03 · Kết nối'},
+              title:{en:'Spaces, Experiences & Community', vi:'Không gian, Trải nghiệm & Cộng đồng'},
+              desc:{en:'Where people meet, experience, and belong.', vi:'Nơi con người gặp gỡ, trải nghiệm và thuộc về.'},
+              brands:[
+                {name:'S&W — Share and Work', url:'https://sw.nhi.sg/', desc:{en:'A shared workspace for collaboration and co-working.', vi:'Không gian làm việc chung — chia sẻ và cộng tác.'}},
+                {name:'This is home — Art & Culture Vietnam', url:'https://tih.nhi.sg/', desc:{en:'A travel company curating Vietnamese art and cultural experiences.', vi:'Công ty du lịch — kiến tạo trải nghiệm văn hoá và nghệ thuật Việt Nam.'}},
+                {name:'BLOOM Retreat', url:'https://bloom.nhi.sg/', desc:{en:'A retreat space for rest and renewal.', vi:'Không gian nghỉ dưỡng và chữa lành.'}},
+                {name:'HUSH Garden Cafe & Workspace', url:'https://hush.nhi.sg/', desc:{en:'A garden cafe paired with a calm workspace.', vi:'Cà phê sân vườn kết hợp không gian làm việc yên tĩnh.'}}
+              ] },
+    care:   { color:'var(--care)',
+              stage:{en:'04 · Give back', vi:'04 · Cho đi'},
+              title:{en:'For the community', vi:'Vì cộng đồng'},
+              desc:{en:'Giving back to make the journey whole.', vi:'Cho đi để hành trình trở nên trọn vẹn.'},
+              brands:[{name:'NhiLe Foundation', url:'https://www.nlf.sg/', desc:{en:'A charitable foundation extending good to the wider community.', vi:'Quỹ thiện nguyện — lan toả giá trị tốt đẹp đến cộng đồng.'}}] },
+    tech:   { color:'var(--tech)',
+              stage:{en:'＋ · Foundation', vi:'＋ · Nền tảng'},
+              title:{en:'Technology', vi:'Công nghệ'},
+              desc:{en:'The digital foundation that holds the whole ecosystem together.', vi:'Nền tảng số gắn kết toàn bộ hệ sinh thái.'},
+              brands:[{name:'Family Cloud', url:'https://familycloud.nhi.sg/', desc:{en:'A cloud technology and digital infrastructure platform — built for the future.', vi:'Nền tảng công nghệ đám mây và hạ tầng số — kiến tạo cho tương lai.'}}] }
+  };
+
+  var nodes = document.querySelectorAll('.node');
+  var panel = document.getElementById('ecoPanel');
+  var pSwatch = document.getElementById('panelSwatch');
+  var pStage = document.getElementById('panelStage');
+  var pTitle = document.getElementById('panelTitle');
+  var pDesc = document.getElementById('panelDesc');
+  var pChips = document.getElementById('panelChips');
+
+  var activeKey = 'edu';
+  function setActive(key){
+    var d = DOMAINS[key]; if(!d) return;
+    activeKey = key;
+    var i, n;
+    for(i=0;i<nodes.length;i++){ nodes[i].classList.toggle('is-active', nodes[i].getAttribute('data-domain')===key); }
+    pSwatch.style.background = d.color;
+    pStage.textContent = d.stage[L];
+    pTitle.textContent = d.title[L];
+    pDesc.textContent = d.desc[L];
+    panel.style.borderColor = d.color;
+    panel.style.boxShadow = '0 24px 60px -30px ' + d.color;
+    pChips.innerHTML = '';
+    for(i=0;i<d.brands.length;i++){
+      var b = d.brands[i];
+      var row = document.createElement('div'); row.className='brow';
+      var dot = document.createElement('span'); dot.className='cdot'; dot.style.background = d.color;
+      var col = document.createElement('div');
+      var nm;
+      if(b.url){
+        nm = document.createElement('a'); nm.href = b.url; nm.target = '_blank'; nm.rel = 'noopener';
+      } else {
+        nm = document.createElement('div');
+      }
+      nm.className='bname'; nm.textContent = b.name;
+      var ds = document.createElement('div'); ds.className='bdesc'; ds.textContent = b.desc[L];
+      col.appendChild(nm); col.appendChild(ds);
+      row.appendChild(dot); row.appendChild(col);
+      pChips.appendChild(row);
+    }
+  }
+  function renderActive(){ setActive(activeKey); }
+
+  for(var i=0;i<nodes.length;i++){
+    (function(node){
+      var key = node.getAttribute('data-domain');
+      node.addEventListener('mouseenter', function(){ setActive(key); });
+      node.addEventListener('click', function(){ setActive(key); });
+      node.addEventListener('keydown', function(e){
+        if(e.key==='Enter' || e.key===' '){ e.preventDefault(); setActive(key); }
+      });
+    })(nodes[i]);
+  }
+  setActive('edu'); /* trạng thái tĩnh mặc định */
+
+  /* ---------- runtime: reveal / journey / count (nội dung luôn hiện; animation bổ sung) ---------- */
+  var reveals = document.querySelectorAll('.reveal');
+  var jp = document.getElementById('journeyPath');
+  var nums = document.querySelectorAll('.num[data-to]');
+
+  function sfx(el){ return el.getAttribute('data-suffix-'+L) || ''; }
+  function runCount(el){
+    if(el.getAttribute('data-counted')){ return; }
+    el.setAttribute('data-counted','1');
+    var to = parseInt(el.getAttribute('data-to'),10);
+    var suffix = sfx(el);
+    if(reduce){ el.textContent = to + suffix; return; }
+    /* an toàn: nếu rAF bị đóng băng, vẫn chốt số cuối */
+    setTimeout(function(){ el.textContent = to + sfx(el); }, 1800);
+    var start = null, dur = 1400;
+    function step(ts){
+      if(start===null) start = ts;
+      var p = Math.min((ts-start)/dur, 1);
+      var eased = 1 - Math.pow(1-p, 3);
+      el.textContent = Math.round(eased*to) + sfx(el);
+      if(p<1) requestAnimationFrame(step);
+    }
+    requestAnimationFrame(step);
+  }
+  function renderNumsSuffix(){
+    for(var i=0;i<nums.length;i++){
+      var el = nums[i];
+      el.textContent = parseInt(el.getAttribute('data-to'),10) + sfx(el);
+    }
+  }
+  function vh(){ return window.innerHeight || document.documentElement.clientHeight || 800; }
+  function inView(el){ var r = el.getBoundingClientRect(); return r.top < vh()*0.96 && r.bottom > 0; }
+
+  if(reduce || !('IntersectionObserver' in window)){
+    /* nội dung đã hiện sẵn (opacity 1) — chỉ cần chốt số liệu */
+    for(var c0=0;c0<nums.length;c0++){ runCount(nums[c0]); }
+  } else {
+    /* 1) tô điểm cho phần đang trong khung nhìn */
+    var p2;
+    for(p2=0;p2<reveals.length;p2++){ if(inView(reveals[p2])){ reveals[p2].classList.add('in'); } }
+    for(p2=0;p2<nums.length;p2++){ if(inView(nums[p2])){ runCount(nums[p2]); } }
+    if(jp && inView(jp)){ jp.classList.add('draw'); }
+
+    /* 2) phần còn lại: tô điểm khi cuộn tới (nếu IO không chạy, nội dung vẫn hiện) */
+    var io = new IntersectionObserver(function(entries){
+      for(var e=0;e<entries.length;e++){
+        if(entries[e].isIntersecting){ entries[e].target.classList.add('in'); io.unobserve(entries[e].target); }
+      }
+    }, { threshold:.12, rootMargin:'0px 0px -6% 0px' });
+    for(var k=0;k<reveals.length;k++){ if(!reveals[k].classList.contains('in')){ io.observe(reveals[k]); } }
+
+    if(jp && !jp.classList.contains('draw')){
+      var pio = new IntersectionObserver(function(ents){
+        for(var x=0;x<ents.length;x++){ if(ents[x].isIntersecting){ jp.classList.add('draw'); pio.disconnect(); } }
+      }, { threshold:.2 });
+      pio.observe(jp);
+    }
+
+    var nio = new IntersectionObserver(function(ents){
+      for(var y=0;y<ents.length;y++){ if(ents[y].isIntersecting){ runCount(ents[y].target); nio.unobserve(ents[y].target); } }
+    }, { threshold:.5 });
+    for(var z=0;z<nums.length;z++){ nio.observe(nums[z]); }
+  }
+
+  /* ---------- nav active state ---------- */
+  var sections = ['hero','ecosystem','journey','proof','cta'];
+  var links = document.querySelectorAll('.navlinks a');
+  function mapLink(id){
+    if(id==='hero') return null;
+    if(id==='journey') return '#journey';
+    return '#'+id;
+  }
+  if('IntersectionObserver' in window){
+    var sio = new IntersectionObserver(function(ents){
+      for(var s=0;s<ents.length;s++){
+        if(ents[s].isIntersecting){
+          var href = mapLink(ents[s].target.id);
+          for(var l=0;l<links.length;l++){
+            links[l].classList.toggle('active', links[l].getAttribute('href')===href);
+          }
+        }
+      }
+    }, { rootMargin:'-45% 0px -50% 0px' });
+    for(var ss=0;ss<sections.length;ss++){
+      var el = document.getElementById(sections[ss]);
+      if(el) sio.observe(el);
+    }
+  }
+  /* ---------- I18N ENGINE (EN default) ---------- */
+  var META = {
+    en:{ title:'NhiLe Holding — An ecosystem for human growth' },
+    vi:{ title:'NhiLe Holding — Hệ sinh thái phát triển con người' }
+  };
+  function applyLang(lang){
+    if(lang!=='en' && lang!=='vi') lang='en';
+    L = lang;
+    document.documentElement.lang = lang;
+    if(META[lang]) document.title = META[lang].title;
+    var els = document.querySelectorAll('[data-en]');
+    for(var i=0;i<els.length;i++){
+      var el = els[i];
+      var val = el.getAttribute('data-'+lang);
+      if(val===null) continue;
+      if(el.hasAttribute('data-html')){ el.innerHTML = val; } else { el.textContent = val; }
+    }
+    var opts = document.querySelectorAll('.lang-opt');
+    for(var o=0;o<opts.length;o++){
+      var on = opts[o].getAttribute('data-lang')===lang;
+      opts[o].classList.toggle('is-active', on);
+      opts[o].setAttribute('aria-pressed', on ? 'true' : 'false');
+    }
+    renderActive();        /* dịch lại panel hệ sinh thái */
+    renderNumsSuffix();    /* dịch lại hậu tố số liệu */
+  }
+  var langOpts = document.querySelectorAll('.lang-opt');
+  for(var lo=0; lo<langOpts.length; lo++){
+    langOpts[lo].addEventListener('click', function(){ applyLang(this.getAttribute('data-lang')); });
+  }
+  applyLang('en'); /* MẶC ĐỊNH: Tiếng Anh / DEFAULT: English */
+})();
+</script>
+</body>
 </html>


### PR DESCRIPTION
## Đồng bộ giao diện landing mới (giống 100% bản đã duyệt)

**Thay đổi:** `index.html` giờ phục vụ trang NhiLe Holding redesign (sơ đồ orbital, EN/VI toggle, link thương hiệu, Living proof, footer Contact) — giống 100% bản HTML đã duyệt.

- Giữ lại Google Analytics (gtag G-FYT955YV53) + meta SEO/OG của `incoming`.
- App React trong `src/` được giữ nguyên (không còn là entry; có thể dọn sau).
- Đã verify: `npm ci` + `vite build` OK → `dist/index.html` ~140.7 kB.
- Liên hệ dùng mailto:contact@nhi.sg + link bản đồ (chưa nối EmailJS — có thể bổ sung sau nếu cần).

Chỉ thay đổi **1 file**: `index.html`. Không đụng `dev`/`main`.